### PR TITLE
Reverse string in Swift: Corrected user input check & index call

### DIFF
--- a/archive/s/swift/reverse-string.swift
+++ b/archive/s/swift/reverse-string.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-guard CommandLine.argc > 0 else {
+guard CommandLine.argc > 1 else {
     exit(0)
 }
 

--- a/archive/s/swift/reverse-string.swift
+++ b/archive/s/swift/reverse-string.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-guard CommandLine.arguments.count > 0 else {
+guard CommandLine.argc > 0 else {
     exit(0)
 }
 

--- a/archive/s/swift/reverse-string.swift
+++ b/archive/s/swift/reverse-string.swift
@@ -4,7 +4,7 @@ guard CommandLine.arguments.count > 0 else {
     exit(0)
 }
 
-let usersString = CommandLine.arguments[0]
+let usersString = CommandLine.arguments[1]
 let reversedCollection = usersString.reversed()
 let reversedString = String(reversedCollection)
 


### PR DESCRIPTION
## Please Complete the Following

- [ ] I would **NOT** like credit for my contribution in the article (credit will be included otherwise)
- [ ] I plan to write the article for this code snippet
- [ ] I named the pull request using `<Sample Program> in <Language>` format
- [ ] I created/updated the language README
  - [ ] I added the sample program name to the README
  - [ ] I added fun facts (i.e. debut, developer, typing, etc.)
  - [ ] I added reference link(s) to the README
- [ X] I fixed #164

## Notes

Commandline.arguments is always initialized with at least one argument inside: the file path. This file path is always located at index 0. To access the user's first input, we must call index 1. 

We must also check to see if the array is longer than 1, to properly know that the user has passed us input. 

Finally, although Commandline.arguments.length will compile, Commandline has the property .argc for checking .arguments' length. It is more in keeping with the spirit of the repo to use this unique language feature, rather than call .length on .arguments.

http://keitaito.com/blog/2017/01/15/swift-scripting-part-1-command-line-arguments.html