### PR TITLE
Moved Style Guide underneath the Reference section

### DIFF
--- a/archive/c/c-plus-plus/README.md
+++ b/archive/c/c-plus-plus/README.md
@@ -14,14 +14,14 @@ Welcome to Sample Programs in C++!
 - Debut: 1985
 - Typing: Static
 
-## Style Guide
+## References
+
+### Style Guide
 For a long time, the styling that you would use in your code would depend on the company you worked for. Google, Mozilla, Apple, etc have their own style guidelines that their employees must follow for a more consistent codebase. Even individual developers form their own styles.
 
 A [set of guidelines](http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines) has been created by Bjarne Stroustrup, the language creator of C++ and Herb Sutter, a well known C++ expert in the community. The document is currently under continuous development, but it still serves well as an excellent place to read up on the best coding practices for C++ projects.
 
 The guidelines are separated into sections that deals with a language topic such as classes and exceptions.
-
-## References
 
 - [C++ Wiki](https://en.wikipedia.org/wiki/C%2B%2B)
 - [CPlusPlus Docs for the C++ language and standard library](http://www.cplusplus.com/)


### PR DESCRIPTION
As per the request of @jrg94 