### PR TITLE
Updates to Fibonacci in Haskell

### DIFF
--- a/archive/h/haskell/fibonacci.hs
+++ b/archive/h/haskell/fibonacci.hs
@@ -1,6 +1,7 @@
 module Main where
 
 import System.Environment
+import Text.Read
 
 fibonacciSequence :: Int -> [Int]
 fibonacciSequence 0            = []
@@ -10,15 +11,22 @@ fibonacciSequence elementCount = go 0 [0,1]
           | otherwise                = sequence
 
 
+headMaybe :: [a] -> Maybe a
+headMaybe []     = Nothing
+headMaybe (x:xs) = Just x
+
+
+-- Takes a list of values and returns a list of strings in the format "ONE_BASED_INDEX: VALUE"
+printWithIndex :: (Show a) => [a] -> [[Char]]
+printWithIndex = zipWith (\i x -> (show i) ++ ": " ++ (show x)) [1..]
+
+
 -- Prints out the first N numbers from the fibonacci sequence
 -- where N equals to the first command line argument.
 main :: IO ()
 main = do
   args <- getArgs
-  let n = head args
-  if null args then
-    error "You need to pass the number of the fibonacci elements to calculate through the command line\n"
-  else
-    let message  = "\nThe first " ++ n ++ " fibonacci numbers are: \n"
-        sequence = fibonacciSequence $ read n
-    in putStrLn $ message ++ show sequence
+  let n = headMaybe args
+  case n >>= readMaybe of
+    Nothing -> putStrLn "Usage: please input the number of fibonacci elements to calculate as a positive integer"
+    Just n  -> mapM_ (putStrLn) $ (printWithIndex . fibonacciSequence) n


### PR DESCRIPTION
This adds error handling discussed [here](https://github.com/TheRenegadeCoder/sample-programs/pull/744#issuecomment-439486262) in #744.

I also modified the output so that it matches the documentation:
```
1: 1
2: 1
3: 2
4: 3
5: 5
```

In doing so I noticed that the original implementation always prints two more numbers than requested including starting with 0. So if I request 5 numbers, instead of the expected above, it will print
```
1: 0
2: 1
3: 1
4: 2
5: 3
6: 5
7: 8
```

I would be happy to fix this as part of this pull request, but it would require me to drastically change the implementation. Or we can merge this as is and give the original author of the solution an opportunity to fix it. @jrg94, Thoughts?