### PR TITLE
Job Sequencing Project Fixes

### DIFF
--- a/docs/projects/job-sequencing-with-deadlines/index.md
+++ b/docs/projects/job-sequencing-with-deadlines/index.md
@@ -29,7 +29,7 @@ following sequence:
 
 Because the last possible job we can choose has a deadline of 3, we can
 only select 3 jobs at most for our sequence. As a result, we cannot
-complete J4. In total, we can make a profit of 40.
+complete J4. In total, we can make a profit of 50.
 
 Be aware that the output sequence is not unique. There may be multiple
 configurations that yield the same profit.
@@ -52,7 +52,7 @@ output the maximum profit only. For example:
 
 ```console
 $ ./job-sequencing.lang "25, 15, 10, 5" "3, 1, 2, 2"
-$ 40
+$ 50
 ```
 
 Naturally, this is for testing
@@ -69,7 +69,7 @@ verify the correctness of your solution:
 | No Input | | "Usage: please provide a list of profits and a list of deadlines" |
 | Empty Input | | "Usage: please provide a list of profits and a list of deadlines" |
 | Missing Input | "25, 15, 10, 5" | "Usage: please provide a list of profits and a list of deadlines" |
-| Sample Input | "25, 15, 10, 5" "3, 1, 2, 2" | "Usage: please provide a list of profits and a list of deadlines" |
+| Sample Input | "25, 15, 10, 5" "3, 1, 2, 2" | 50 |
 
 ## Articles
 

--- a/docs/projects/job-sequencing-with-deadlines/index.md
+++ b/docs/projects/job-sequencing-with-deadlines/index.md
@@ -70,6 +70,7 @@ verify the correctness of your solution:
 | Empty Input | | "Usage: please provide a list of profits and a list of deadlines" |
 | Missing Input | "25, 15, 10, 5" | "Usage: please provide a list of profits and a list of deadlines" |
 | Sample Input | "25, 15, 10, 5" "3, 1, 2, 2" | 50 |
+| Sample Input | "20, 15, 10, 5, 1" "2, 2, 1, 3, 3" | 40 |
 
 ## Articles
 


### PR DESCRIPTION
This is some changes to the Job Sequencing with Deadlines project.

First of all the expected output was incorrect for the sample input.

Second, I added another sample input (found from the further reading video by Abdul Bari).
The existing sample input doesn't take advantage of the greedy method because you can just use the 3 jobs with the most profit.
The new sample input requires that you skip one of the top profit jobs due to a deadline.