### PR TITLE
Test build

### DIFF
--- a/archive/p/python/testinfo.yml
+++ b/archive/p/python/testinfo.yml
@@ -4,5 +4,5 @@ folder:
 
 container:
   image: "python"
-  tag: "3.7"
+  tag: "3.7-alpine"
   cmd: "python {{ source.name }}{{ source.extension }}"

--- a/archive/r/ruby/testinfo.yml
+++ b/archive/r/ruby/testinfo.yml
@@ -4,5 +4,5 @@ folder:
 
 container:
   image: "ruby"
-  tag: "2"
+  tag: "2-alpine"
   cmd: "ruby {{ source.name }}{{ source.extension }}"

--- a/test/containerfactory.py
+++ b/test/containerfactory.py
@@ -2,6 +2,8 @@ import docker
 import shutil
 import tempfile
 
+from uuid import uuid4 as uuid
+
 
 class Singleton(type):
     _instances = {}
@@ -38,6 +40,7 @@ class ContainerFactory:
         if key not in cls._containers:
             cls._containers[key] = cls._client.containers.run(
                 image=image,
+                name=f'{source.name}_{uuid().hex}',
                 command='sleep 1h',
                 working_dir='/src',
                 volumes=volume_info,
@@ -53,10 +56,23 @@ class ContainerFactory:
         :param container_info: metadata about the image to pull
         :return: a docker image
         """
+        images = cls._client.images.list(name=f'{container_info.image}:{str(container_info.tag)}')
+        if len(images) == 1:
+            return images[0]
         return cls._client.images.pull(container_info.image, tag=str(container_info.tag))
 
     @classmethod
-    def _cleanup(cls, source):
+    def cleanup(cls, source):
+        """
+        Cleanup docker container and temporary folder. Also remove both from their
+        respective dictionaries
+
+        :param source: source for determining what to cleanup
+        """
         key = source.full_path
+
+        cls._containers[key].remove(v=True, force=True)
+        shutil.rmtree(cls._volume_dis[key], ignore_errors=True)
+
         del cls._volume_dis[key]
         del cls._containers[key]

--- a/test/containerfactory.py
+++ b/test/containerfactory.py
@@ -1,0 +1,62 @@
+import docker
+import shutil
+import tempfile
+
+
+class Singleton(type):
+    _instances = {}
+
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            instance = super().__call__(*args, **kwargs)
+            cls._instances[cls] = instance
+        return cls._instances[cls]
+
+
+class ContainerFactory:
+    _containers = {}
+    _volume_dis = {}
+    _client = docker.from_env()
+
+    @classmethod
+    def get_container(cls, source):
+        """
+        Returns a running container for a give source. This will return an existing container if one exists
+        or create a new one if necessary
+
+        :param source: the source to use inside the container
+        :return: a running container specific to the source
+        """
+        key = source.full_path
+
+        tmp_dir = tempfile.mkdtemp()
+        shutil.copy(source.full_path, tmp_dir)
+        cls._volume_dis[key] = tmp_dir
+
+        image = cls._get_image(source.test_info.container_info)
+        volume_info = {tmp_dir: {'bind': '/src', 'mode': 'rw'}}
+        if key not in cls._containers:
+            cls._containers[key] = cls._client.containers.run(
+                image=image,
+                command='sleep 1h',
+                working_dir='/src',
+                volumes=volume_info,
+                detach=True,
+            )
+        return cls._containers[key]
+
+    @classmethod
+    def _get_image(cls, container_info):
+        """
+        Pull a docker image
+
+        :param container_info: metadata about the image to pull
+        :return: a docker image
+        """
+        return cls._client.images.pull(container_info.image, tag=str(container_info.tag))
+
+    @classmethod
+    def _cleanup(cls, source):
+        key = source.full_path
+        del cls._volume_dis[key]
+        del cls._containers[key]

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -1,13 +1,5 @@
-import docker
-import pytest
-
 from test import source
 from test.project import ProjectType
-
-
-@pytest.fixture
-def docker_client():
-    return docker.from_env()
 
 
 class ProjectPermutation:

--- a/test/projects/test_baklava.py
+++ b/test/projects/test_baklava.py
@@ -2,17 +2,19 @@ import os
 
 import pytest
 
-from test.fixtures import project_permutations, docker_client
+from test.fixtures import project_permutations
 from test.project import ProjectType
 
 
 @pytest.fixture(params=project_permutations[ProjectType.Baklava].params,
-                ids=project_permutations[ProjectType.Baklava].ids)
+                ids=project_permutations[ProjectType.Baklava].ids,
+                scope='module')
 def baklava(request):
-    return request.param
+    yield request.param
+    request.param.cleanup()
 
 
-def test_baklava(docker_client, baklava):
+def test_baklava(baklava):
     expected = """          *
          ***
         *****
@@ -36,6 +38,6 @@ def test_baklava(docker_client, baklava):
           *
 """
     expected_lines = expected.split(os.linesep)
-    actual = baklava.run(docker_client)
+    actual = baklava.run()
     actual_lines = actual.split(os.linesep)
     assert actual_lines == expected_lines

--- a/test/projects/test_even_odd.py
+++ b/test/projects/test_even_odd.py
@@ -1,6 +1,6 @@
 import pytest
 
-from test.fixtures import project_permutations, docker_client
+from test.fixtures import project_permutations
 from test.project import ProjectType
 
 invalid_permutations = (
@@ -45,20 +45,22 @@ valid_permutations = (
 
 
 @pytest.fixture(params=project_permutations[ProjectType.EvenOdd].params,
-                ids=project_permutations[ProjectType.EvenOdd].ids)
+                ids=project_permutations[ProjectType.EvenOdd].ids,
+                scope='module')
 def even_odd(request):
-    return request.param
+    yield request.param
+    request.param.cleanup()
 
 
 @pytest.mark.parametrize(valid_permutations[0], valid_permutations[1],
                          ids=[p[0] for p in valid_permutations[1]])
-def test_even_odd_valid(description, in_params, expected, docker_client, even_odd):
-    actual = even_odd.run(docker_client, params=in_params)
+def test_even_odd_valid(description, in_params, expected, even_odd):
+    actual = even_odd.run(params=in_params)
     assert actual.replace('[', '').replace(']', '').strip() == expected
 
 
 @pytest.mark.parametrize(invalid_permutations[0], invalid_permutations[1],
                          ids=[p[0] for p in invalid_permutations[1]])
-def test_even_odd_invalid(description, in_params, expected, docker_client, even_odd):
-    actual = even_odd.run(docker_client, params=in_params, expect_error=True)
+def test_even_odd_invalid(description, in_params, expected, even_odd):
+    actual = even_odd.run(params=in_params)
     assert actual.strip() == expected

--- a/test/projects/test_factorial.py
+++ b/test/projects/test_factorial.py
@@ -1,6 +1,6 @@
 import pytest
 
-from test.fixtures import project_permutations, docker_client
+from test.fixtures import project_permutations
 from test.project import ProjectType
 
 invalid_permutations = (
@@ -53,20 +53,22 @@ valid_permutations = (
 
 
 @pytest.fixture(params=project_permutations[ProjectType.Factorial].params,
-                ids=project_permutations[ProjectType.Factorial].ids)
+                ids=project_permutations[ProjectType.Factorial].ids,
+                scope='module')
 def factorial(request):
-    return request.param
+    yield request.param
+    request.param.cleanup()
 
 
 @pytest.mark.parametrize(valid_permutations[0], valid_permutations[1],
                          ids=[p[0] for p in valid_permutations[1]])
-def test_factorial_valid(description, in_params, expected, docker_client, factorial):
-    actual = factorial.run(docker_client, params=in_params)
+def test_factorial_valid(description, in_params, expected, factorial):
+    actual = factorial.run(params=in_params)
     assert actual.strip() == expected
 
 
 @pytest.mark.parametrize(valid_permutations[0], valid_permutations[1],
                          ids=[p[0] for p in valid_permutations[1]])
-def test_factorial_invalid(description, in_params, expected, docker_client, factorial):
-    actual = factorial.run(docker_client, params=in_params, expect_error=True)
+def test_factorial_invalid(description, in_params, expected, factorial):
+    actual = factorial.run(params=in_params)
     assert actual.strip() == expected

--- a/test/projects/test_fizz_buzz.py
+++ b/test/projects/test_fizz_buzz.py
@@ -1,6 +1,6 @@
 import pytest
 
-from test.fixtures import project_permutations, docker_client
+from test.fixtures import project_permutations
 from test.project import ProjectType
 
 
@@ -108,11 +108,13 @@ Buzz
 
 
 @pytest.fixture(params=project_permutations[ProjectType.FizzBuzz].params,
-                ids=project_permutations[ProjectType.FizzBuzz].ids)
+                ids=project_permutations[ProjectType.FizzBuzz].ids,
+                scope='module')
 def fizz_buzz(request):
-    return request.param
+    yield request.param
+    request.param.cleanup()
 
 
-def test_fizz_buzz(docker_client, fizz_buzz):
-    actual = fizz_buzz.run(docker_client)
+def test_fizz_buzz(fizz_buzz):
+    actual = fizz_buzz.run()
     assert actual == expected

--- a/test/projects/test_hello_world.py
+++ b/test/projects/test_hello_world.py
@@ -1,15 +1,17 @@
 import pytest
 
-from test.fixtures import project_permutations, docker_client
+from test.fixtures import project_permutations
 from test.project import ProjectType
 
 
 @pytest.fixture(params=project_permutations[ProjectType.HelloWorld].params,
-                ids=project_permutations[ProjectType.HelloWorld].ids)
+                ids=project_permutations[ProjectType.HelloWorld].ids,
+                scope='module')
 def hello_world(request):
-    return request.param
+    yield request.param
+    request.param.cleanup()
 
 
-def test_hello_world(docker_client, hello_world):
-    actual = hello_world.run(docker_client)
+def test_hello_world(hello_world):
+    actual = hello_world.run()
     assert actual.strip() == 'Hello, World!'

--- a/test/projects/test_job_sequencing.py
+++ b/test/projects/test_job_sequencing.py
@@ -1,6 +1,6 @@
 import pytest
 
-from test.fixtures import project_permutations, docker_client
+from test.fixtures import project_permutations
 from test.project import ProjectType
 
 invalid_permutations = (
@@ -37,20 +37,22 @@ valid_permutations = (
 
 
 @pytest.fixture(params=project_permutations[ProjectType.JobSequencing].params,
-                ids=project_permutations[ProjectType.JobSequencing].ids)
+                ids=project_permutations[ProjectType.JobSequencing].ids,
+                scope='module')
 def job_sequencing(request):
-    return request.param
+    yield request.param
+    request.param.cleanup()
 
 
 @pytest.mark.parametrize(valid_permutations[0], valid_permutations[1],
                          ids=[p[0] for p in valid_permutations[1]])
-def test_job_sequencing_valid(description, in_params, expected, docker_client, job_sequencing):
-    actual = job_sequencing.run(docker_client, params=in_params)
+def test_job_sequencing_valid(description, in_params, expected, job_sequencing):
+    actual = job_sequencing.run(params=in_params)
     assert actual.strip() == expected
 
 
 @pytest.mark.parametrize(invalid_permutations[0], invalid_permutations[1],
                          ids=[p[0] for p in invalid_permutations[1]])
-def test_job_sequencing_invalid(description, in_params, expected, docker_client, job_sequencing):
-    actual = job_sequencing.run(docker_client, params=in_params, expect_error=True)
+def test_job_sequencing_invalid(description, in_params, expected, job_sequencing):
+    actual = job_sequencing.run(params=in_params)
     assert actual.strip() == expected

--- a/test/projects/test_lcs.py
+++ b/test/projects/test_lcs.py
@@ -1,6 +1,6 @@
 import pytest
 
-from test.fixtures import project_permutations, docker_client
+from test.fixtures import project_permutations
 from test.project import ProjectType
 from test.utilities import clean_list
 
@@ -38,20 +38,22 @@ valid_permutations = (
 
 
 @pytest.fixture(params=project_permutations[ProjectType.LCS].params,
-                ids=project_permutations[ProjectType.LCS].ids)
+                ids=project_permutations[ProjectType.LCS].ids,
+                scope='module')
 def lcs(request):
-    return request.param
+    yield request.param
+    request.param.cleanup()
 
 
 @pytest.mark.parametrize(valid_permutations[0], valid_permutations[1],
                          ids=[p[0] for p in valid_permutations[1]])
-def test_lcs_valid(description, in_params, expected, docker_client, lcs):
-    actual = lcs.run(docker_client, params=in_params)
+def test_lcs_valid(description, in_params, expected, lcs):
+    actual = lcs.run(params=in_params)
     assert clean_list(actual) == expected
 
 
 @pytest.mark.parametrize(invalid_permutations[0], invalid_permutations[1],
                          ids=[p[0] for p in invalid_permutations[1]])
-def test_lcs_invalid(description, in_params, expected, docker_client, lcs):
-    actual = lcs.run(docker_client, params=in_params, expect_error=True)
+def test_lcs_invalid(description, in_params, expected, lcs):
+    actual = lcs.run(params=in_params)
     assert actual.strip() == expected

--- a/test/projects/test_quine.py
+++ b/test/projects/test_quine.py
@@ -1,6 +1,6 @@
 import pytest
 
-from test.fixtures import project_permutations, docker_client
+from test.fixtures import project_permutations
 from test.project import ProjectType
 
 
@@ -10,12 +10,14 @@ def _get_expected(source):
 
 
 @pytest.fixture(params=project_permutations[ProjectType.Quine].params,
-                ids=project_permutations[ProjectType.Quine].ids)
+                ids=project_permutations[ProjectType.Quine].ids,
+                scope='module')
 def quine(request):
-    return request.param
+    yield request.param
+    request.param.cleanup()
 
 
-def test_quine(docker_client, quine):
+def test_quine(quine):
     expected = _get_expected(quine)
-    actual = quine.run(docker_client)
+    actual = quine.run()
     assert actual == expected

--- a/test/projects/test_reverse_string.py
+++ b/test/projects/test_reverse_string.py
@@ -1,15 +1,16 @@
 import pytest
 
-from test.fixtures import project_permutations, docker_client
+from test.fixtures import project_permutations
 from test.project import ProjectType
 
 
 @pytest.fixture(params=project_permutations[ProjectType.ReverseString].params,
                 ids=project_permutations[ProjectType.ReverseString].ids)
 def reverse_string(request):
-    return request.param
+    yield request.param
+    request.param.cleanup()
 
 
-def test_reverse_string(docker_client, reverse_string):
-    actual = reverse_string.run(docker_client, params='"Hello, World"')
+def test_reverse_string(reverse_string):
+    actual = reverse_string.run(params='"Hello, World"')
     assert actual.strip() == 'dlroW ,olleH'

--- a/test/projects/test_sorting.py
+++ b/test/projects/test_sorting.py
@@ -1,6 +1,6 @@
 import pytest
 
-from test.fixtures import project_permutations, docker_client
+from test.fixtures import project_permutations
 from test.project import sorting_types
 from test.utilities import clean_list
 
@@ -62,20 +62,22 @@ sorting_project_permutations = _get_sorting_project_permutations()
 
 
 @pytest.fixture(params=sorting_project_permutations.params,
-                ids=sorting_project_permutations.ids)
+                ids=sorting_project_permutations.ids,
+                scope='module')
 def sort_source(request):
-    return request.param
+    yield request.param
+    request.param.cleanup()
 
 
 @pytest.mark.parametrize(sorting_valid_permutations[0], sorting_valid_permutations[1],
                          ids=[p[0] for p in sorting_valid_permutations[1]])
-def test_sort_valid(description, in_params, expected, docker_client, sort_source):
-    actual = sort_source.run(docker_client, params=in_params)
+def test_sort_valid(description, in_params, expected, sort_source):
+    actual = sort_source.run(params=in_params)
     assert clean_list(actual) == expected
 
 
 @pytest.mark.parametrize(sorting_invalid_permutations[0], sorting_invalid_permutations[1],
                          ids=[p[0] for p in sorting_invalid_permutations[1]])
-def test_sort_invalid(description, in_params, expected, docker_client, sort_source):
-    actual = sort_source.run(docker_client, params=in_params, expect_error=True)
+def test_sort_invalid(description, in_params, expected, sort_source):
+    actual = sort_source.run(params=in_params)
     assert actual.strip() == expected

--- a/test/testinfo.py
+++ b/test/testinfo.py
@@ -17,17 +17,19 @@ class NamingScheme(Enum):
 class ContainerInfo:
     """Configuration for a container to run for a directory"""
 
-    def __init__(self, image, tag, cmd):
+    def __init__(self, image, tag, cmd, build=None):
         """
         Initialize a ContainerInfo
 
         :param image: the image to run
         :param tag: the tag of the image to run
-        :param cmd: the command to run in the container
+        :param cmd: the command to run the source inside the container
+        :param build: an optional command to run to build the source before running the command
         """
         self._image = image
         self._cmd = cmd
         self._tag = tag
+        self._build = build
 
     @property
     def image(self):
@@ -36,13 +38,18 @@ class ContainerInfo:
 
     @property
     def cmd(self):
-        """Returns the command to run in the container"""
+        """Returns the command to run the source inside the container"""
         return self._cmd
 
     @property
     def tag(self):
         """Returns the tag of the image to run"""
         return self._tag
+
+    @property
+    def build(self):
+        """Returns the command to build the source before running it inside the container"""
+        return self._build
 
     @classmethod
     def from_dict(cls, dictionary):
@@ -52,7 +59,16 @@ class ContainerInfo:
         :param dictionary: the dictionary representing ContainerInfo
         :return: a new ContainerInfo
         """
-        return ContainerInfo(dictionary['image'], dictionary['tag'], dictionary['cmd'])
+        image = dictionary['image']
+        tag = dictionary['tag']
+        cmd = dictionary['cmd']
+        build = dictionary['build'] if 'build' in dictionary else None
+        return ContainerInfo(
+            image=image,
+            tag=tag,
+            cmd=cmd,
+            build=build
+        )
 
 
 class FolderInfo:


### PR DESCRIPTION
There are a few major changes in this pull request.

I moved all docker functionality into a single module. The `Source.run()` function now just calls the factory to get a container.

Having a container factory allows us to keep a container around for all permutations of a test function instead of spinning up a new container each time. For example:
I can run `bubble_sort.py "345,345,234,5"` and `bubble_sort.py ""` from the same container, but if I were to run bubble sort in any other language or if I were to run any other `.py` snippet, I would get a new container.

Containers and temporary directories are now torn down at the end of each module run. (See the `pytest.fixture` for each test)

These changes allow us to run all tests in an average of 14 seconds on my machine compared to the 3+ minute average I was seeing earlier.