### PR TITLE
Use alpine image for node

### DIFF
--- a/archive/j/javascript/testinfo.yml
+++ b/archive/j/javascript/testinfo.yml
@@ -4,5 +4,5 @@ folder:
 
 container:
   image: "node"
-  tag: "11-slim"
+  tag: "11-alpine"
   cmd: "node {{ source.name }}{{ source.extension }}"


### PR DESCRIPTION
We should try use "alpine" images wherever possible. The more alpine images we can use, the smaller and quicker our build will be. If alpine is not available we should look for slim.

Node does have an alpine build, so I switched to it from slim.