### PR TITLE
Updated ReverseString in Lua

### DIFF
--- a/archive/l/lua/reverse-string.lua
+++ b/archive/l/lua/reverse-string.lua
@@ -1,3 +1,3 @@
-if #arg > 1 then
+if #arg > 0 then
     print(string.reverse(arg[1]))
 end


### PR DESCRIPTION
Congrats on taking the first step to contributing to the Sample Programs repository maintained by [The Renegade Coder][1]! For simplicity, please make sure that your pull request includes one and only one contribution.

## Complete the Applicable Sections Below

Find which section best describes your pull request and make sure you fill it out. To start, let us know which issue you've fixed.

- [x] I fixed #1164

### Code Snippets

- [x] I named the pull request using `Added/Updated <Sample Program> in <Language>` format
- [ ] I created/updated the language README
  - [ ] I added the sample program name to the README
  - [ ] I added fun facts (i.e. debut, developer, typing, etc.)
  - [ ] I added reference link(s) to the README
  - [ ] I added solution citations when necessary (see [plagiarism][2])

### Documentation

- [ ] I named the pull request using `Added/Updated <Sample Program> in <Language> Article` format
- [ ] I followed the applicable article template
  - [ ] I added/updated a [language article][4] (i.e. The Python Programming Language)
  - [ ] I added/updated a [code snippet article][3] (i.e. Hello World in Perl)
  - [ ] I added/updated a [project article][5] (i.e. Fizz Buzz in Every Language)

### Testing

- [ ] I names the pull request using `Added/Updated <Language>/<Project> Testing` format
- [ ] I followed the testinfo template, if applicable

## Notes

The `#arg` syntax -  the Lua length operator - has some strange behavior. (Go ahead, read for yourself: http://www.lua.org/manual/5.2/manual.html#3.4.6) The operator DOESN'T actually calculate length. It can ONLY be expected to work properly for length calculation in the case where a table's keys are a valid sequence (e.g. 0,1,2...n) and in that case the length is `n`. This means the the comparison in the original sample:

```lua
if #arg > 1 then
...
```
never entered the `if` block. Or could only enter the `if` block if the user passed two or more args.

Why? Because `arg[0]` is the name of the file being executed (i.e. `reverse-string.lua`) and `arg[1]` is the user's input. If we check `#arg > 1` (which in most other languages would make sense, because, ya know, counting), we're effectively asking Lua to make sure that `arg[0]`, `arg[1]`, and `arg[2]` are present. 

So changing the comparison to:

```lua
if #arg > 0 then
...
``` 
gives us the correct comparison logic for verifying that the user has provided a string to reverse. 

Lua is fun! (Seriously, https://www.hammerspoon.org/) But it's got some strange edges.

[1]: https://therenegadecoder.com/
[2]: https://github.com/TheRenegadeCoder/sample-programs/blob/master/.github/CONTRIBUTING.md#plagiarism
[3]: https://github.com/TheRenegadeCoder/sample-programs/blob/master/docs/templates/CODE_ARTICLE_TEMPLATE.md
[4]: https://github.com/TheRenegadeCoder/sample-programs/blob/master/docs/templates/LANGUAGE_ARTICLE_TEMPLATE.md
[5]: https://github.com/TheRenegadeCoder/sample-programs/blob/master/docs/templates/PROJECT_ARTICLE_TEMPLATE.md
