### PR TITLE
Fixed article tag links for all language articles

### DIFF
--- a/docs/languages/_posts/2019-05-01-julia.md
+++ b/docs/languages/_posts/2019-05-01-julia.md
@@ -1,7 +1,7 @@
 ---
 title: The Julia Programming Language
 layout: default
-last-modified: 2019-05-02
+last-modified: 2019-10-30
 featured-image: 
 tags: [julia]
 authors:
@@ -28,6 +28,10 @@ numerical analysis.
 Finally, Julia has metaprogramming features, so the language can be 
 modified as needed by the user. If Julia ever takes off, we can probably 
 expect several different dialects of it to emerge.[^grifski_hwjulia_2018]
+
+## Articles
+
+{% include article_list.md collection=site.tags.julia %}
 
 ---
 

--- a/docs/languages/_posts/2019-05-02-wren.md
+++ b/docs/languages/_posts/2019-05-02-wren.md
@@ -1,7 +1,7 @@
 ---
 title: The Wren Programming Language
 layout: default
-last-modified: 2019-05-02
+last-modified: 2019-10-30
 featured-image: 
 tags: [wren]
 authors:
@@ -29,6 +29,10 @@ fibers generally only switch when they are told to—much like coroutines.
 Finally, Wren is incredibly fast for a scripting language. In fact, the website 
 shares some benchmarks which demonstrate it outperforming Python, Lua, and 
 JavaScript. Game developers should be pretty happy about this.[^grifski_hwwren_2018]
+
+## Articles
+
+{% include article_list.md collection=site.tags.wren %}
 
 ---
 

--- a/docs/languages/_posts/2019-05-07-elm.md
+++ b/docs/languages/_posts/2019-05-07-elm.md
@@ -1,7 +1,7 @@
 ---
 title: The Elm Programming Language
 layout: default
-last-modified: 2019-05-07
+last-modified: 2019-10-30
 featured-image: 
 tags: [elm]
 authors:
@@ -72,6 +72,10 @@ a = a - 5
 Because a is immutable, the code above will actually cause a recursion 
 error. You can read more about that in Elm’s documentation. At any rate, 
 let’s get to the solution![^grifski_hwelm_2018]
+
+## Articles
+
+{% include article_list.md collection=site.tags.elm %}
 
 ---
 

--- a/docs/languages/_posts/2019-05-07-hack.md
+++ b/docs/languages/_posts/2019-05-07-hack.md
@@ -1,7 +1,7 @@
 ---
 title: The Hack Programming Language
 layout: default
-last-modified: 2019-05-07
+last-modified: 2019-10-30
 featured-image: 
 tags: [hack]
 authors:
@@ -57,6 +57,10 @@ languages like Hack and Python have. It’s called gradual typing, and it allows
 users to specify exactly when they want static or dynamic typing.
 
 Once again, I think I’ve explored a topic a bit too deeply, so I’ll stop there.[^grifski_hwhack_2018]
+
+## Articles
+
+{% include article_list.md collection=site.tags.hack %}
 
 ---
 

--- a/docs/languages/_posts/2019-05-12-pascal.md
+++ b/docs/languages/_posts/2019-05-12-pascal.md
@@ -1,7 +1,7 @@
 ---
 title: The Pascal Programming Language
 layout: default
-last-modified: 2019-05-12
+last-modified: 2019-10-30
 featured-image: 
 tags: [pascal]
 authors:
@@ -69,6 +69,10 @@ if i in [5..20] then
 ```
 
 At any rate, I think we’ve played around enough[^grifski_hwpascal_2018].
+
+## Articles
+
+{% include article_list.md collection=site.tags.pascal %}
 
 ---
 

--- a/docs/languages/_posts/2019-05-16-elixir.md
+++ b/docs/languages/_posts/2019-05-16-elixir.md
@@ -56,7 +56,7 @@ we have to get to our implementation of Hello World in Elixir[^grifski_hwelixir_
 
 ## Articles
 
-{% include article_list.md collection=site.tags.elixr %}
+{% include article_list.md collection=site.tags.elixir %}
 
 ---
 #### References

--- a/docs/languages/_posts/2019-05-16-elixir.md
+++ b/docs/languages/_posts/2019-05-16-elixir.md
@@ -1,7 +1,7 @@
 ---
 title: The Elixir Programming Language
 layout: default
-last-modified: 2019-05-16
+last-modified: 2019-10-30
 featured-image: 
 tags: [elixir]
 authors:
@@ -54,8 +54,11 @@ z  # "some string"
 In addition, there are several other ways pattern matching can be used, but 
 we have to get to our implementation of Hello World in Elixir[^grifski_hwelixir_2018].
 
----
+## Articles
 
+{% include article_list.md collection=site.tags.elixr %}
+
+---
 #### References
 
 {% include blog_reference.md reference="grifski_hwelixir_2018" %}

--- a/docs/languages/_posts/2019-05-29-perl.md
+++ b/docs/languages/_posts/2019-05-29-perl.md
@@ -1,7 +1,7 @@
 ---
 title: The Perl Programming Language
 layout: default
-last-modified: 2019-05-29
+last-modified: 2019-10-30
 featured-image: 
 tags: [perl]
 authors:
@@ -29,6 +29,10 @@ As a fun tidbit, Perl differs dramatically from Python in terms of complexity.
 In fact, the creators of Perl live by the slogan “there’s more than one way to 
 do it.” In contrary, the creators of Python prefer that “there should be one — 
 and preferably only one — obvious way to do it“[^grifski_hwperl_2018]
+
+## Articles
+
+{% include article_list.md collection=site.tags.perl %}
 
 ---
 

--- a/docs/languages/_posts/2019-05-29-scala.md
+++ b/docs/languages/_posts/2019-05-29-scala.md
@@ -1,7 +1,7 @@
 ---
 title: The Scala Programming Language
 layout: default
-last-modified: 2019-05-29
+last-modified: 2019-10-30
 featured-image: 
 tags: [scala]
 authors:
@@ -44,6 +44,10 @@ That’s pretty cool stuff!
 
 At any rate, we probably shouldn’t dive too much further. After all, we have 
 yet to implement Hello World in Scala[^grifski_hwscala_2018].
+
+## Articles
+
+{% include article_list.md collection=site.tags.scala %}
 
 ---
 

--- a/docs/languages/_posts/2019-07-01-haskell.md
+++ b/docs/languages/_posts/2019-07-01-haskell.md
@@ -1,7 +1,7 @@
 ---
 title: The Haskell Programming Language
 layout: default
-last-modified: 2019-07-01
+last-modified: 2019-10-30
 featured-image: 
 tags: [haskell]
 authors:
@@ -27,6 +27,10 @@ are only evaluated when they are needed. If my explanation is bad, take a
 look at the article I linked above. It covers the concept in great depth.
 
 At any rate, I think that’s plenty of background for now[^grifski_hwhaskell_2018].
+
+## Articles
+
+{% include article_list.md collection=site.tags.haskell %}
 
 ---
 

--- a/docs/languages/_posts/2019-08-22-lisp.md
+++ b/docs/languages/_posts/2019-08-22-lisp.md
@@ -1,7 +1,7 @@
 ---
 title: The Lisp Programming Language
 layout: default
-last-modified: 2019-08-22
+last-modified: 2019-10-30
 featured-image: 
 tags: [lisp]
 authors:
@@ -107,7 +107,9 @@ a function called foo. We can then call foo from anywhere in our program:
 How cool is that? I think I’m starting to like Lisp. Of course, we haven’t even gotten to 
 implement Hello World in Lisp, so we should probably get to that.
 
-For the purposes of this exercise, we’ll be using the latest Steel Bank version of Common Lisp[^grifski_hwlisp_2018].
+## Articles
+
+{% include article_list.md collection=site.tags.lisp %}
 
 ---
 


### PR DESCRIPTION
Just went through the whole list and made sure the articles section was there.
Should I have updated the article dates in this case? I can change those back if you want.
