### PR TITLE
Assert statement used outside of tests

### DIFF
--- a/test/projects/test_rot_13.py
+++ b/test/projects/test_rot_13.py
@@ -49,7 +49,8 @@ def rot_13(request):
                          ids=[p[0] for p in valid_permutations[1]])
 def test_rot_13_valid(description, in_params, expected, rot_13):
     actual = rot_13.run(params=in_params)
-    assert actual.strip() == expected
+   if actual.strip() != expected:
+        raise AssertionError
 
 
 @project_test(ProjectType.ROT13.key)


### PR DESCRIPTION
 assert actual.strip() == expected



Usage of assert statement in application logic is discouraged. assert is removed with compiling to optimised byte code (python -o producing *.pyo files). Consider raising an exception instead. Ideally, assert statement should be used only in tests.

Tip: Make sure test_patterns are defined in .deepsource.toml to avoid false-positives - https://deepsource.io/docs/config/deepsource-toml.html#test-patterns

Congrats on taking the first step to contributing to the Sample Programs repository maintained by [The Renegade Coder][1]! 
For simplicity, please make sure that your pull request includes one and only one contribution.

## Complete the Applicable Sections Below

Find which section best describes your pull request and make sure you fill it out. To start, let us know which issue you've fixed.

- [ ] I fixed #your-issue-number-here

### Code Snippets

- [ ] I named the pull request using `Added/Updated <Sample Program> in <Language>` format
- [ ] I created/updated the language README
  - [ ] I added the sample program name to the README
  - [ ] I added fun facts (i.e. debut, developer, typing, etc.)
  - [ ] I added reference link(s) to the README
  - [ ] I added solution citations when necessary (see [plagiarism][2])

### Testing

- [ ] I named the pull request using `Added/Updated <Language>/<Project> Testing` format
- [ ] I followed the testinfo template, if applicable

## Notes

Feel free to describe what you added or updated.

[1]: https://therenegadecoder.com/
[2]: https://github.com/TheRenegadeCoder/sample-programs/blob/master/.github/CONTRIBUTING.md#plagiarism
