### PR TITLE
Comparing to literal

### DIFF
--- a/archive/p/python/prime_number.py
+++ b/archive/p/python/prime_number.py
@@ -2,7 +2,6 @@
 import sys
 from math import sqrt, ceil
 
-
 def is_prime(x):
     if (x % 2 == 0 and x is not 2) or (x == 1):
         return False


### PR DESCRIPTION
 7    if (x % 2 == 0 and x is not 2) or (x == 1):
Comparing an object to a literal is usually something you do not want to do, since you can compare to a different literal than what was expected altogether.

Congrats on taking the first step to contributing to the Sample Programs repository maintained by [The Renegade Coder][1]! 
For simplicity, please make sure that your pull request includes one and only one contribution.

## Complete the Applicable Sections Below

Find which section best describes your pull request and make sure you fill it out. To start, let us know which issue you've fixed.

- [ ] I fixed #your-issue-number-here

### Code Snippets

- [ ] I named the pull request using `Added/Updated <Sample Program> in <Language>` format
- [ ] I created/updated the language README
  - [ ] I added the sample program name to the README
  - [ ] I added fun facts (i.e. debut developer, typing, etc.)
  - [ ] I added reference link(s) to the README
  - [ ] I added solution citations when necessary (see [plagiarism][2])

### Testing

- [ ] I named the pull request using `Added/Updated <Language>/<Project> Testing` format
- [ ] I followed the testinfo template, if applicable

## Notes

Feel free to describe what you added or updated.

[1]: https://therenegadecoder.com/
[2]: https://github.com/TheRenegadeCoder/sample-programs/blob/master/.github/CONTRIBUTING.md#plagiarism
