### PR TITLE
Added Roman Numeral Conversion in Ruby

### DIFF
--- a/archive/r/ruby/README.md
+++ b/archive/r/ruby/README.md
@@ -14,6 +14,7 @@ Welcome to Sample Programs in Ruby!
 - [Quine in Ruby][4]
 - [Reverse String in Ruby][11]
 - Even Odd in Ruby
+- [Roman Numeral Conversion][14]
 
 ## Fun Facts
 
@@ -41,3 +42,4 @@ Welcome to Sample Programs in Ruby!
 [11]: https://therenegadecoder.com/code/reverse-a-string-in-ruby/
 [12]: https://github.com/TheRenegadeCoder/sample-programs/issues/542
 [13]: https://github.com/TheRenegadeCoder/sample-programs/issues/1023
+[14]: https://github.com/TheRenegadeCoder/sample-programs/issues/1532

--- a/archive/r/ruby/roman-numeral.rb
+++ b/archive/r/ruby/roman-numeral.rb
@@ -21,10 +21,11 @@ def roman_valid?(roman_numbers)
 end
 
 def roman_to_decimal(full_roman_number)
+  return 'Usage: please provide a string of roman numerals' if full_roman_number.nil?
   return 0 if full_roman_number.empty?
 
   roman_numbers = full_roman_number.upcase.split('')
-  raise 'Invalid Roman Number' unless roman_valid?(roman_numbers)
+  return 'Error: invalid string of roman numerals' unless roman_valid?(roman_numbers)
 
   previous = 0
   total = 0
@@ -37,7 +38,7 @@ def roman_to_decimal(full_roman_number)
     previous = value
   end
 
-  p total
+  total
 end
 
-roman_to_decimal(ARGV[0])
+p roman_to_decimal(ARGV[0])

--- a/archive/r/ruby/roman-numeral.rb
+++ b/archive/r/ruby/roman-numeral.rb
@@ -27,18 +27,20 @@ def roman_to_decimal(full_roman_number)
   roman_numbers = full_roman_number.upcase.split('')
   return 'Error: invalid string of roman numerals' unless roman_valid?(roman_numbers)
 
-  previous = 0
   total = 0
 
-  roman_numbers.each do |roman_number|
-    value = ROMAN_VALUES[roman_number.to_sym]
-
-    total += value if (value >= previous)
-    total -= value unless (value >= previous)
-    previous = value
+  roman_numbers.each_with_index do |roman_number, index|
+    current_value = ROMAN_VALUES[roman_number.to_sym]
+    next_value = ROMAN_VALUES[roman_numbers[index+1]&.to_sym] || 0
+    
+    if (current_value >= next_value)
+      total += current_value
+    else
+      total -= current_value
+    end
   end
 
   total
 end
 
-p roman_to_decimal(ARGV[0])
+print(roman_to_decimal(ARGV[0]))

--- a/archive/r/ruby/roman-numeral.rb
+++ b/archive/r/ruby/roman-numeral.rb
@@ -1,0 +1,43 @@
+ROMAN_VALUES = {
+  "I": 1,
+  "V": 5,
+  "X": 10,
+  "L": 50,
+  "C": 100,
+  "D": 500,
+  "M": 1000
+}
+
+def roman_valid?(roman_numbers)
+  return false if roman_numbers.any? { |roman_number| !ROMAN_VALUES.keys.include?(roman_number.to_sym) }  
+  return false if roman_numbers.join.include?('MMMM')
+  
+  counter_numbers = roman_numbers.tally # Only on ruby 2.7+
+  unless counter_numbers['M'].nil?
+    return false if counter_numbers['M'] > 4
+  end
+  
+  counter_numbers.reject { |k| k == 'M' }.all? { |(_, counter)| counter <= 3 }
+end
+
+def roman_to_decimal(full_roman_number)
+  return 0 if full_roman_number.empty?
+
+  roman_numbers = full_roman_number.upcase.split('')
+  raise 'Invalid Roman Number' unless roman_valid?(roman_numbers)
+
+  previous = 0
+  total = 0
+
+  roman_numbers.each do |roman_number|
+    value = ROMAN_VALUES[roman_number.to_sym]
+
+    total += value if (value >= previous)
+    total -= value unless (value >= previous)
+    previous = value
+  end
+
+  p total
+end
+
+roman_to_decimal(ARGV[0])


### PR DESCRIPTION
### Complete the Applicable Sections Below

- [x] I fixed #2146

### Code Snippets

- [x] I named the pull request using `Added/Updated <Sample Program> in <Language>` format
- [x] I created/updated the language README
  - [x] I added the sample program name to the README
  - [x] I added reference link(s) to the README

### Testing

- [x] Run `ruby archive/r/ruby/roman-numeral.rb VALID_ROMAN_NUMBER`

## Notes

I created the code to convert Roman numeral in Ruby. I used the method `tally` that is only available on `ruby 2.7+`. If you use a older version it will break.