### PR TITLE
Added Even Odd in Elixir

### DIFF
--- a/archive/e/elixir/README.md
+++ b/archive/e/elixir/README.md
@@ -10,6 +10,7 @@ Welcome to Sample Programs in Elixir!
 - [Bubble Sort in Elixir](https://github.com/TheRenegadeCoder/sample-programs/issues/1138)
 - Factorial in Elixir
 - [Longest Common Subsequence](https://sample-programs.therenegadecoder.com/projects/longest-common-subsequence/)
+- Even Odd in Elixir
 
 ## Fun Facts
 

--- a/archive/e/elixir/even_odd.ex
+++ b/archive/e/elixir/even_odd.ex
@@ -3,7 +3,7 @@ defmodule EvenOdd do
 
     @doc """
     Determine whether a supplied number is Even or Odd.
-    Return a 'usage' string if the argument is invalid. 
+    Return an error-string if the argument is missing or invalid. 
     """
     @spec main(argv :: list( String.t())) :: String.t()
     def main(argv) do

--- a/archive/e/elixir/even_odd.ex
+++ b/archive/e/elixir/even_odd.ex
@@ -1,0 +1,30 @@
+defmodule EvenOdd do
+    require Integer
+
+    @doc """
+    Determine whether a supplied number is Even or Odd.
+    Return a 'usage' string if the argument is invalid. 
+    """
+    @spec main(argv :: list( String.t())) :: String.t()
+    def main(argv) do
+        if length(argv) != 1 do
+            "Usage: please input a number"
+        else 
+            case argv |> List.first |> Integer.parse do
+                {number, ""} -> even_odd_string(number)
+                {_, _rest} -> "Usage: please input a number"
+                :error -> "Usage: please input a number"
+            end
+        end
+    end
+
+    @spec even_odd_string(number :: integer) :: String.t()
+    defp even_odd_string(number) do
+        case Integer.is_even(number) do
+            true -> "Even"
+            false -> "Odd"
+        end
+    end
+end
+
+EvenOdd.main(System.argv()) |> IO.puts


### PR DESCRIPTION
Congrats on taking the first step to contributing to the Sample Programs repository maintained by [The Renegade Coder][1]! 
For simplicity, please make sure that your pull request includes one and only one contribution.

## Complete the Applicable Sections Below

Find which section best describes your pull request and make sure you fill it out. To start, let us know which issue you've fixed.

- [ ] I fixed #your-issue-number-here

### Code Snippets

- [x] I named the pull request using `Added/Updated <Sample Program> in <Language>` format
- [x] I created/updated the language README
  - [x] I added the sample program name to the README
  - [ ] I added fun facts (i.e. debut developer, typing, etc.)
  - [ ] I added reference link(s) to the README
  - [ ] I added solution citations when necessary (see [plagiarism][2])

### Testing

- [ ] I named the pull request using `Added/Updated <Language>/<Project> Testing` format
- [ ] I followed the testinfo template, if applicable

## Notes

Idiomatic Elixir code would probably wrap the error/result in a tuple ( `{:ok, "Even"} / {:error, "Usage: ...."}` ). However, I'm not an Elixir expert and the existing Elixir code in this repository also doesn't to it. Though wrapping the result in a tuple would be more true to the language in my opinion.
Then again, it would lead to a bit more complex code as there would need to be an additional function `[1]` that takes the tuple and prints the result/error regardless if there was an error or not, in order to fulfill the project requirements.

Feedback is welcome. If this is pull request is acceptable I would implement a few more projects in Elixir.

[1]: https://therenegadecoder.com/
[2]: https://github.com/TheRenegadeCoder/sample-programs/blob/master/.github/CONTRIBUTING.md#plagiarism


`[1]`:
    
    defp print_result({_state, res}) do
      res |> IO.puts
    end
