### PR TITLE
Fixed Links in LOLCODE README

### DIFF
--- a/archive/l/lolcode/README.md
+++ b/archive/l/lolcode/README.md
@@ -15,5 +15,5 @@ Welcome to Sample Programs in LOLCODE!
 
 ## References
 
-- [Lua Wiki](https://en.wikipedia.org/wiki/Lua_(programming_language))
-- [Lua Docs](https://www.lua.org/)
+- [LOLCODE wiki](https://en.wikipedia.org/wiki/LOLCODE)
+- [LOLCODE Docs](http://www.lolcode.org/)


### PR DESCRIPTION
This is PR to solve Incorrect Links in Lolcode README.
The README of Lolcode has links to Lua docs in the References section.
I have added the original links.
It fixes #2200




