### PR TITLE
Add tests for existing language template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -37,6 +37,15 @@ For more information please refer to our [contributing documentation][contributi
 - [ ] I verified the project exists on the [Sample Programs Project List][sample-programs-project-list]
 - [ ] I added tests for every test case in the Testing table of the project description for the given project. (See [contributing documentation][contributing-tests-in-detail])
 
+
+## I Am Adding New Tests for a Language
+
+- [ ] I fixed #your-issue-number-here
+- [ ] I named the pull request using `Add {LANGUAGE} tests` format\
+- [ ] I added a `testinfo.yml` files (see [contributing documentation][contributing-new-language])
+  - [ ] I used an officially supported docker image or one that I personally trust
+- [ ] I verified all tests are passing
+
   
 ## I Am Modifying an Existing Code Snippet or Existing Tests
 

--- a/.github/PULL_REQUEST_TEMPLATE/code-snippet.md
+++ b/.github/PULL_REQUEST_TEMPLATE/code-snippet.md
@@ -29,5 +29,5 @@ Feel free to describe what you added or updated.
 
 [renegade-coder]: https://therenegadecoder.com/
 [contributing-plagiarism]: https://github.com/TheRenegadeCoder/sample-programs/blob/master/.github/CONTRIBUTING.md#plagiarism
-[contributing-readme]: https://github.com/TheRenegadeCoder/sample-programs/blob/contributing/.github/CONTRIBUTING.md#create-readmes
+[contributing-readme]: https://github.com/TheRenegadeCoder/sample-programs/blob/master/.github/CONTRIBUTING.md#create-readmes
 [contributing]: ../CONTRIBUTING.md

--- a/.github/PULL_REQUEST_TEMPLATE/existing-language-tests.md
+++ b/.github/PULL_REQUEST_TEMPLATE/existing-language-tests.md
@@ -1,0 +1,31 @@
+---
+name: New Project Tests
+about: Add tests for an existing language
+title: Add {LANGUAGE} tests
+labels: enhancement, tests
+reviewers: '@TheRenegadeCoder/core'
+assignees: ''
+---
+
+Congrats on taking the first step to contributing to the Sample Programs repository maintained by [The Renegade Coder][renegade-coder]! 
+For simplicity, please make sure that your pull request includes one and only one contribution.
+
+## Complete the Applicable Sections Below
+
+Please fill out the following sections.
+For more information please refer to our [contributing documentation][contributing]
+
+- [ ] I fixed #your-issue-number-here
+- [ ] I named the pull request using `Add {LANGUAGE} tests` format\
+- [ ] I added a `testinfo.yml` files (see [contributing documentation][contributing-new-language])
+  - [ ] I used an officially supported docker image or one that I personally trust
+- [ ] I modified existing snippets to meet the testing requirements
+- [ ] I verified all tests are passing
+  
+## Notes
+
+Feel free to describe what you added or updated.
+
+[renegade-coder]: https://therenegadecoder.com/
+[contributing-new-language]: https://github.com/TheRenegadeCoder/sample-programs/blob/master/.github/CONTRIBUTING.md#requirements-for-a-new-language
+[contributing]: ../CONTRIBUTING.md

--- a/.github/PULL_REQUEST_TEMPLATE/new-language-code-snippet.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new-language-code-snippet.md
@@ -31,6 +31,6 @@ Feel free to describe what you added or updated.
 
 [renegade-coder]: https://therenegadecoder.com/
 [contributing-plagiarism]: https://github.com/TheRenegadeCoder/sample-programs/blob/master/.github/CONTRIBUTING.md#plagiarism
-[contributing-new-language]: https://github.com/TheRenegadeCoder/sample-programs/blob/contributing/.github/CONTRIBUTING.md#requirements-for-a-new-language
-[contributing-readme]: https://github.com/TheRenegadeCoder/sample-programs/blob/contributing/.github/CONTRIBUTING.md#create-readmes
+[contributing-new-language]: https://github.com/TheRenegadeCoder/sample-programs/blob/master/.github/CONTRIBUTING.md#requirements-for-a-new-language
+[contributing-readme]: https://github.com/TheRenegadeCoder/sample-programs/blob/master/.github/CONTRIBUTING.md#create-readmes
 [contributing]: ../CONTRIBUTING.md

--- a/.github/PULL_REQUEST_TEMPLATE/new-project-tests.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new-project-tests.md
@@ -27,7 +27,7 @@ Feel free to describe what you added or updated.
 [renegade-coder]: https://therenegadecoder.com/
 [contributing-plagiarism]: https://github.com/TheRenegadeCoder/sample-programs/blob/master/.github/CONTRIBUTING.md#plagiarism
 [contributing-new-project]: https://github.com/TheRenegadeCoder/sample-programs/blob/master/.github/CONTRIBUTING.md#requirements-for-a-new-project
-[contributing-readme]: https://github.com/TheRenegadeCoder/sample-programs/blob/contributing/.github/CONTRIBUTING.md#create-readmes
-[contributing-tests-in-detail]: https://github.com/TheRenegadeCoder/sample-programs/blob/contributing/.github/CONTRIBUTING.md#tests-in-detail
+[contributing-readme]: https://github.com/TheRenegadeCoder/sample-programs/blob/master/.github/CONTRIBUTING.md#create-readmes
+[contributing-tests-in-detail]: https://github.com/TheRenegadeCoder/sample-programs/blob/master/.github/CONTRIBUTING.md#tests-in-detail
 [contributing]: ../CONTRIBUTING.md
 [sample-programs-project-list]: https://sample-programs.therenegadecoder.com/projects/

--- a/.github/PULL_REQUEST_TEMPLATE/new-project-tests.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new-project-tests.md
@@ -26,7 +26,7 @@ Feel free to describe what you added or updated.
 
 [renegade-coder]: https://therenegadecoder.com/
 [contributing-plagiarism]: https://github.com/TheRenegadeCoder/sample-programs/blob/master/.github/CONTRIBUTING.md#plagiarism
-[contributing-new-project]: https://github.com/TheRenegadeCoder/sample-programs/blob/contributing/.github/CONTRIBUTING.md#requirements-for-a-new-project
+[contributing-new-project]: https://github.com/TheRenegadeCoder/sample-programs/blob/master/.github/CONTRIBUTING.md#requirements-for-a-new-project
 [contributing-readme]: https://github.com/TheRenegadeCoder/sample-programs/blob/contributing/.github/CONTRIBUTING.md#create-readmes
 [contributing-tests-in-detail]: https://github.com/TheRenegadeCoder/sample-programs/blob/contributing/.github/CONTRIBUTING.md#tests-in-detail
 [contributing]: ../CONTRIBUTING.md


### PR DESCRIPTION
We missed the template for adding testing to an existing language in our first pass at documentation. This adds it.