### PR TITLE
Added Credit to Main README

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -44,8 +44,9 @@ Many of the solutions in this repo we created in collaboration with folks
 trying to accomplish similar goals. Special thanks to the following folks
 for sharing their work with our repo:
 
-- [@toturkmen][toturkmen-profile] for their [Baklava Repo][baklava-repo]
 - [@auroq][auroq-profile] for their development of [Glotter][glotter-repo]
+- [@joesephwegner][joesephwegner-profile] for their [ineverylang Repo][ineverylang-repo]
+- [@toturkmen][toturkmen-profile] for their [Baklava Repo][baklava-repo]
 
 [1]: http://www.100daysofcode.com/
 [2]: https://therenegadecoder.com/code/hello-world-in-every-language/
@@ -71,6 +72,8 @@ for sharing their work with our repo:
 [auroq-profile]: https://github.com/auroq
 [baklava-repo]: https://github.com/toturkmen/baklava
 [glotter-repo]: https://github.com/auroq/glotter
+[ineverylang-repo]: https://github.com/josephwegner/ineverylang
+[joesephwegner-profile]: https://github.com/josephwegner
 [sample-programs-news-series]: https://therenegadecoder.com/series/sample-programs-repo-news/
 [sample-programs-on-the-renegade-coder]: https://therenegadecoder.com/code/sample-programs-in-every-language/
 [toturkmen-profile]: https://github.com/toturkmen

--- a/.github/README.md
+++ b/.github/README.md
@@ -41,7 +41,7 @@ Thanks for your support! :relaxed:
 ## Special Thanks
 
 Many of the solutions in this repo we created in collaboration with folks
-trying to accomplish similar things. Special thanks to the following folks
+trying to accomplish similar goals. Special thanks to the following folks
 for sharing their work with our repo:
 
 - [@toturkmen][toturkmen-profile] for their [Baklava Repo][baklava-repo]

--- a/.github/README.md
+++ b/.github/README.md
@@ -38,6 +38,14 @@ a part of my website, [The Renegade Coder][10]. If you're looking to support The
 
 Thanks for your support! :relaxed:
 
+## Special Thanks
+
+Many of the solutions in this repo we created in collaboration with folks
+trying to accomplish similar things. Special thanks to the following folks
+for sharing their work with our repo:
+
+- [@toturkmen][toturkmen-profile] for their [Baklava Repo][baklava-repo]
+
 [1]: http://www.100daysofcode.com/
 [2]: https://therenegadecoder.com/code/hello-world-in-every-language/
 [3]: https://therenegadecoder.com/code/reverse-a-string-in-every-language/
@@ -59,5 +67,7 @@ Thanks for your support! :relaxed:
 [19]: https://therenegadecoder.com/code/python-code-snippets-for-everyday-problems/
 [20]: https://sample-programs.therenegadecoder.com/projects/
 
+[baklava-repo]: https://github.com/toturkmen/baklava
 [sample-programs-news-series]: https://therenegadecoder.com/series/sample-programs-repo-news/
 [sample-programs-on-the-renegade-coder]: https://therenegadecoder.com/code/sample-programs-in-every-language/
+[toturkmen-profile]: https://github.com/toturkmen

--- a/.github/README.md
+++ b/.github/README.md
@@ -40,7 +40,7 @@ Thanks for your support! :relaxed:
 
 ## Special Thanks
 
-Many of the solutions in this repo we created in collaboration with folks
+Many of the solutions in this repo were created in collaboration with folks
 trying to accomplish similar goals. Special thanks to the following folks
 for sharing their work with our repo:
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -45,6 +45,7 @@ trying to accomplish similar goals. Special thanks to the following folks
 for sharing their work with our repo:
 
 - [@toturkmen][toturkmen-profile] for their [Baklava Repo][baklava-repo]
+- [@auroq][auroq-profile] for their development of [Glotter][glotter-repo]
 
 [1]: http://www.100daysofcode.com/
 [2]: https://therenegadecoder.com/code/hello-world-in-every-language/
@@ -67,7 +68,9 @@ for sharing their work with our repo:
 [19]: https://therenegadecoder.com/code/python-code-snippets-for-everyday-problems/
 [20]: https://sample-programs.therenegadecoder.com/projects/
 
+[auroq-profile]: https://github.com/auroq
 [baklava-repo]: https://github.com/toturkmen/baklava
+[glotter-repo]: https://github.com/auroq/glotter
 [sample-programs-news-series]: https://therenegadecoder.com/series/sample-programs-repo-news/
 [sample-programs-on-the-renegade-coder]: https://therenegadecoder.com/code/sample-programs-in-every-language/
 [toturkmen-profile]: https://github.com/toturkmen


### PR DESCRIPTION
The automation of the READMEs is going to cause some information to be lost. For example, any time we gave credit to a repo for their work. I wanted to move that credit to the forefront README. 

Obviously, there are other sections that are going to take a hit: Fun Facts, Resources, etc. 