### PR TITLE
Moved generate_docs Requirement to Requirements.txt

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -36,7 +36,6 @@ jobs:
         
     - name: Generate READMEs
       run: |
-        pip install generate_docs==2.2.0
         wikir archive/
         
     - name: Commit READMEs

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,5 @@ __pycache__/
 .scratch
 # erlang
 *.beam
-
+/venv/
 .DS_Store

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 glotter>=0.1.44, <0.2.0
 pytest>=5.2.1, <5.3
+generate_docs~=2.2.0


### PR DESCRIPTION
I decided to do this, so that all dependencies were in a single place. Also, so it shows the dependency in GitHub's dependency graph. 