### PR TITLE
Pulled README Generation Out Into Its Own Workflow

### DIFF
--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -1,0 +1,44 @@
+# This workflow generates READMEs for all languages
+
+name: README Generation
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+        
+    - name: Install Dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install generate_docs==2.2.0
+        
+    - name: Generate READMEs
+      run: |
+        wikir archive/
+        
+    - name: Commit READMEs
+      uses: EndBug/add-and-commit@v5 
+      with:
+        message: |
+          Generated READMEs from sources
+          
+          
+          on-behalf-of: @TheRenegadeCoder <jeremy.grifski@therenegadecoder.com>
+        author_name: Jeremy Grifski
+        author_email: jeremy.grifski@therenegadecoder.com
+        
+      env:
+        # This is necessary in order to push a commit to the repo
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Leave this line unchanged

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -1,4 +1,4 @@
-# This workflow will install Python dependencies, build READMEs, download Docker images, and test every script in the repo
+# This workflow will install Python dependencies, download Docker images, and test every script in the repo
 
 name: Test Suite
 
@@ -33,23 +33,3 @@ jobs:
     - name: Test All Sample Programs
       run: |
         python runner.py test
-        
-    - name: Generate READMEs
-      run: |
-        pip install generate_docs==2.2.0
-        wikir archive/
-        
-    - name: Commit READMEs
-      uses: EndBug/add-and-commit@v5 
-      with:
-        message: |
-          Generated READMEs from sources
-          
-          
-          on-behalf-of: @TheRenegadeCoder <jeremy.grifski@therenegadecoder.com>
-        author_name: Jeremy Grifski
-        author_email: jeremy.grifski@therenegadecoder.com
-        
-      env:
-        # This is necessary in order to push a commit to the repo
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Leave this line unchanged

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -43,7 +43,7 @@ jobs:
       uses: EndBug/add-and-commit@v5 
       with:
         message: |
-          Generated READMEs from sources [skip ci]
+          Generated READMEs from sources
           
           
           on-behalf-of: @TheRenegadeCoder <jeremy.grifski@therenegadecoder.com>


### PR DESCRIPTION
I had this idea to include [skip-ci] in the commit message of README generation. I did this because I didn't want READMEs to be generated on the main branch, only on pull requests. Unfortunately, when I squash pull requests, the [skip-ci] message is added to the aggregate pull request causing the deployment not to run (i.e., no updated wiki).

Right now, I've chosen to remove that message from commit, but I'm thinking there may be a way to separate these out into different actions, so READMEs are only generated on pull requests. Unfortunately, testing will be run twice. This is another thing I was trying to avoid. Something to think about. 