### PR TITLE
README Workflow Works on Push Only

### DIFF
--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -2,9 +2,7 @@
 
 name: README Generation
 
-on:
-  pull_request:
-    branches: [ main ]
+on: push
 
 jobs:
   build:


### PR DESCRIPTION
README workflow doesn't appear to work on pull requests. I read that if we switch the workflow over to push, then it should work on forks. This couldn't hurt considering everything we do is through branches. The only reason I set it up for pull requests was to ensure READMEs were never built on main. As long as we maintain pull request workflow, this should be a non-issue. 