### PR TITLE
Converted README Generation to Push Only

### DIFF
--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -2,7 +2,10 @@
 
 name: README Generation
 
-on: push
+on: 
+  push:
+    branches:
+      - 'main'
 
 jobs:
   build:

--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -2,10 +2,7 @@
 
 name: README Generation
 
-on: 
-  pull_request_target:
-    branches:
-      - 'main'
+on: push
 
 jobs:
   build:


### PR DESCRIPTION
I can't seem to get READMEs to generate on pull request. I've tried a variety of techniques such as using `pull_request_target`. I think I'm going to have to switch this to pushing on Main only. 