### PR TITLE
Add COBOL Tests

### DIFF
--- a/archive/c/cobol/testinfo.yml
+++ b/archive/c/cobol/testinfo.yml
@@ -1,0 +1,9 @@
+folder:
+  extension: ".cbl"
+  naming: "hyphen"
+
+container:
+  image: "sinenomine/cobol-s390x"
+  tag: "latest"
+  build: "cobc -x {{ source.name }}{{ source.extension }}"
+  cmd: "./{{ source.name }}"


### PR DESCRIPTION
Not working yet

Congrats on taking the first step to contributing to the Sample Programs repository maintained by [The Renegade Coder][renegade-coder]! 
For simplicity, please make sure that your pull request includes one and only one contribution.

Please fill _one_ of the sections below as applicable.
Please also add any other relevant information to the Notes section at the bottom.
You may delete or just ignore any other sections.
For more information please refer to our [contributing documentation][contributing]

## I Am Adding New Tests for a Language

- [ ] I fixed #2490 
- [x] I named the pull request using `Add {LANGUAGE} tests` format\
- [x] I added a `testinfo.yml` files (see [contributing documentation][contributing-new-language])
  - [ ] I used an officially supported docker image or one that I personally trust
- [ ] I verified all tests are passing


## Other Notes

I am getting this error and I can't figure out why:

```
e = HTTPError('409 Client Error: Conflict for url: http+docker://localhost/v1.35/containers/f53fc06940c943115d0eeb5a0260edb16cef04e670a558446c1fd66aa31b8d68/exec')

    def create_api_error_from_http_exception(e):
        """
        Create a suitable APIError from requests.exceptions.HTTPError.
        """
        response = e.response
        try:
            explanation = response.json()['message']
        except ValueError:
            explanation = (response.content or '').strip()
        cls = APIError
        if response.status_code == 404:
            if explanation and ('No such image' in str(explanation) or
                                'not found: does not exist or no pull access'
                                in str(explanation) or
                                'repository does not exist' in str(explanation)):
                cls = ImageNotFound
            else:
                cls = NotFound
>       raise cls(e, response=response, explanation=explanation)
E       docker.errors.APIError: 409 Client Error: Conflict ("Container f53fc06940c943115d0eeb5a0260edb16cef04e670a558446c1fd66aa31b8d68 is not running")                                                                                                                  

/home/sudhanshu/.local/lib/python3.9/site-packages/docker/errors.py:31: APIError
```

@jrg94 can you help me with this?