### PR TITLE
Added Sample Programs Docs as Submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "docs"]
+	path = docs
+	url = https://github.com/TheRenegadeCoder/sample-programs-website


### PR DESCRIPTION
When I put together subete, I only used this repo as a way of generating statistics about the code in this repo. Over time, I grew a need for getting the complete list of available projects. However, I didn't want to add a requirement for having multiple git repos on your system. Adding the website as a submodule allows me to update subete to retrieve the complete list of projects from the start which we can check against the list of programs in each language folder. I'm excited by these change because it means we can write other tools to help check if folks name their code correctly, among other things. 