### PR TITLE
Fixed Bug in Binary Search in C++

### DIFF
--- a/archive/c/c-plus-plus/binary-search.cpp
+++ b/archive/c/c-plus-plus/binary-search.cpp
@@ -91,7 +91,7 @@ int main(int argc,char* argv[]){
 		int mid=(start+end)/2;
 
 		if(num<v[mid]){
-			end=mid-1;
+			end=mid;
 		}else if(v[mid]<num){
 			start=mid+1;
 		}else if(v[mid]==num){


### PR DESCRIPTION
The algorithm failed when the target value is before the midpoint of array.


## I Am Adding a New Code Snippet in an Existing Language

- [ ] I named the pull request using `Add {PROJECT} in {LANGUAGE}` format
  
  