### PR TITLE
Add Job Sequencing in Mathematica

### DIFF
--- a/archive/m/mathematica/job-sequencing.nb
+++ b/archive/m/mathematica/job-sequencing.nb
@@ -1,0 +1,53 @@
+(* Code *)
+
+(* The actual job scheduler which takes a Mathematica list of job tuples (value, deadline): *)
+
+schedule = jobs \[Function] 
+   Total[Part[(* sum the values of the scheduled jobs *)
+     (* keep removing jobs until all the deadlines can be met *)
+     FixedPoint[
+      (* remove a single job *)
+      l \[Function] Module[
+        (* find the position 'i' of the first job that fails to meet its deadline *)
+        {i = SelectFirst[Range[Length[l]], # > l[[#, 2]] &]},
+        If[MissingQ[i],
+         l,(* all deadlines are met *)
+         (* else, delete the lowest-value job at or before that position 'i' *)
+         Delete[l, First[MinimalBy[Range[i], l[[#, 1]] &]]]]],
+      (* sort jobs by increasing deadline *)
+      SortBy[jobs, job \[Function] job[[2]]]],
+     All, 1]];
+
+(* The outer function provides the 'user interface': *)
+
+scheduleMain = Function[{values, deadlines},
+   Module[{e = "Usage: please provide a list of profits and a list of deadlines"},
+    Catch[
+     schedule[
+      Map[
+       (* convert string to integer, or throw *)
+       s \[Function] If[StringMatchQ[s, DigitCharacter ..],
+         FromDigits[s],
+         Throw[e]],
+       (* construct argument to scheduler: list of job tuples *)
+       Module[{
+         vs = StringSplit[values, ", "],
+         ds = StringSplit[deadlines, ", "]
+         },
+        If[Length[vs] == Length[ds] \[And] Length[vs] > 0, Transpose[{vs, ds}], Throw[e]]],
+       {-1} (* at each leaf *)]]]]];
+
+
+(* Valid Tests *)
+
+Print /@ Apply[scheduleMain] /@ {
+    {"25, 15, 10, 5", "3, 1, 2, 2"},
+    {"20, 15, 10, 5, 1", "2, 2, 1, 3, 3"}
+    };
+
+
+(* Invalid Tests *)
+
+scheduleMain["", ""]
+scheduleMain["25, 15, 10, 5", ""]
+scheduleMain["1, 2, 3, 4", "1, 2, 3, 4, 5"]


### PR DESCRIPTION
## I Am Adding a New Code Snippet in an Existing Language

- [X] I fixed #2639 
- [X] I named the pull request using `Add {PROJECT} in {LANGUAGE}` format
  
  
## Other Notes

Please see my description in the Issue as to the structure of the code and why the tests can only be run manually; any such tests required by the project are included as part of the Pull Request and were verified by me (the author).

Note that this PR is a result of exporting the Mathematica Notebook as text, which drastically reduces its readability: within the Mathematica environment itself the Notebook looks much better, showing both input and output, elegantly formatted.  If you (the Web site maintainers) like, I can provide the Notebook contents as exported HTML (with or without MathML), and the original Notebooks themselves— just let me know.