### PR TITLE
Add Longest Common Subsequence in Mathematica

### DIFF
--- a/archive/m/mathematica/longest-common-subsequence.nb
+++ b/archive/m/mathematica/longest-common-subsequence.nb
@@ -1,0 +1,53 @@
+(* Code *)
+
+(* Longest Common Subsequence option longestCommonSubsequence1 is just a Mathematica built-in
+   (note that Mathematica LongestCommonSubsequence searches only for contiguous subsequences): *)
+
+longestCommonSubsequence1 = LongestCommonSequence;
+
+(* If that is considered cheating, then option longestCommonSubsequence2 implements it directly: *)
+
+longestCommonSubsequence2 = Function[{l, r},
+   (* if either list is empty, the LCS is also empty *)
+   If[Length[l] == 0 \[Or] Length[r] == 0, {},
+    (* if first element of both lists match, recurse after removing that element *)
+    If[First[l] == First[r],
+     Prepend[longestCommonSubsequence2[Rest[l], Rest[r]], First[l]],
+     (* recurse by computing LCS of removing either first element from the left or from the right list *)
+     Module[{ll = longestCommonSubsequence2[Rest[l], r], rr = longestCommonSubsequence2[l, Rest[r]]},
+      (* pick whichever produces the longest LCS *)
+      If[Length[ll] > Length[rr], ll, rr]]]]];
+
+(* The outer function provides the 'user interface' (e.g., the string parsing): *)
+
+longestCommonSubsequenceMain = Function[{left, right},
+   Module[{e = "Usage: please provide two lists in the format \"1,2,3,4,5\""},
+    Catch[
+     StringRiffle[
+      longestCommonSubsequence2 @@
+       Map[
+        (* convert string to integer, or throw *)
+        s \[Function] If[StringMatchQ[s, DigitCharacter ..],
+          FromDigits[s],
+          Throw[e]],
+        (* construct two arguments to longestCommonSubsequence: left list, right list *)
+        {
+         If[StringLength[left] > 0, StringSplit[left, ", "], Throw[e]],
+         If[StringLength[right] > 0, StringSplit[right, ", "], 
+          Throw[e]]
+         },
+        {-1} (* at each leaf *)],
+       ", "]]]];
+
+
+(* Valid Tests *)
+
+Print /@ Apply[longestCommonSubsequenceMain] /@ {
+    {"1, 4, 5, 3, 15, 6", "1, 7, 4, 5, 11, 6"},
+    {"1, 4, 8, 6, 9, 3, 15, 11, 6", "1, 7, 4, 5, 8, 11, 6"}
+    };
+
+
+(* Invalid Tests *)
+
+longestCommonSubsequenceMain["3", ""]


### PR DESCRIPTION
## I Am Adding a New Code Snippet in an Existing Language

- [X] I fixed #2642 
- [X] I named the pull request using `Add {PROJECT} in {LANGUAGE}` format
  
  
## Other Notes

Please see my description in the Issue as to the structure of the code and why the tests can only be run manually; any such tests required by the project are included as part of the Pull Request and were verified by me (the author).

Note that this PR is a result of exporting the Mathematica Notebook as text, which drastically reduces its readability: within the Mathematica environment itself the Notebook looks much better, showing both input and output, elegantly formatted.  If you (the Web site maintainers) like, I can provide the Notebook contents as exported HTML (with or without MathML), and the original Notebooks themselves— just let me know.