### PR TITLE
Add Longest Palindromic Substring in Mathematica

### DIFF
--- a/archive/m/mathematica/longest-palindromic-substring.nb
+++ b/archive/m/mathematica/longest-palindromic-substring.nb
@@ -1,0 +1,34 @@
+(* Code *)
+
+(* Brute force approach of generating all substrings and testing: *)
+
+longestPalindromicSubstring = word \[Function] First @ MaximalBy[
+     Select[PalindromeQ][
+      Flatten[Table[
+        StringTake[word, {i, j}],
+        {i, 1, StringLength[word]}, {j, i + 1, StringLength[word]}],
+       1]],
+     StringLength,
+     UpTo[1]];
+
+(* The outer function provides the 'user interface' (e.g., the string parsing): *)
+
+longestPalindromicSubstringMain = Function[{s},
+   Module[{e = "Usage: please provide a string that contains at least one palindrome"},
+    Catch[
+     longestPalindromicSubstring @
+      If[StringLength[s] > 0, s, Throw[e]]]]];
+
+
+(* Valid Tests *)
+
+Print /@ longestPalindromicSubstringMain /@ {
+    "racecar",
+    "kayak mom",
+    "step on no pets"
+    };
+
+
+(* Invalid Tests *)
+
+longestPalindromicSubstringMain[""]


### PR DESCRIPTION
## I Am Adding a New Code Snippet in an Existing Language

- [X] I fixed #2643 
- [X] I named the pull request using `Add {PROJECT} in {LANGUAGE}` format
  
  
## Other Notes

Please see my description in the Issue as to the structure of the code and why the tests can only be run manually; any such tests required by the project are included as part of the Pull Request and were verified by me (the author).

Note that this PR is a result of exporting the Mathematica Notebook as text, which drastically reduces its readability: within the Mathematica environment itself the Notebook looks much better, showing both input and output, elegantly formatted.  If you (the Web site maintainers) like, I can provide the Notebook contents as exported HTML (with or without MathML), and the original Notebooks themselves— just let me know.