### PR TITLE
Add Longest Word in Mathematica

### DIFF
--- a/archive/m/mathematica/longest-word.nb
+++ b/archive/m/mathematica/longest-word.nb
@@ -1,0 +1,27 @@
+(* Code *)
+
+(* Trivial: *)
+
+longestWord = s \[Function] Max @@ StringLength /@ StringSplit[s];
+
+(* The outer function provides the 'user interface' (e.g., the string parsing): *)
+
+longestWordMain = Function[{s},
+   Module[{e = "Usage: please provide a string"},
+    Catch[
+     longestWord @
+      If[StringLength[s] > 0, s, Throw[e]]]]];
+
+
+(* Valid Tests *)
+
+Print /@ longestWord /@ {
+    "May the force be with you",
+    "Floccinaucinihilipilification",
+    "Hi,\nMy name is Paul!"
+    };
+
+
+(* Invalid Tests *)
+
+longestWordMain[""]


### PR DESCRIPTION
## I Am Adding a New Code Snippet in an Existing Language

- [X] I fixed #2644 
- [X] I named the pull request using `Add {PROJECT} in {LANGUAGE}` format
  
  
## Other Notes

Please see my description in the Issue as to the structure of the code and why the tests can only be run manually; any such tests required by the project are included as part of the Pull Request and were verified by me (the author).

Note that this PR is a result of exporting the Mathematica Notebook as text, which drastically reduces its readability: within the Mathematica environment itself the Notebook looks much better, showing both input and output, elegantly formatted.  If you (the Web site maintainers) like, I can provide the Notebook contents as exported HTML (with or without MathML), and the original Notebooks themselves— just let me know.