### PR TITLE
Add Roman Numeral in Mathematica

### DIFF
--- a/archive/m/mathematica/roman-numerals.nb
+++ b/archive/m/mathematica/roman-numerals.nb
@@ -1,0 +1,36 @@
+(* Code *)
+
+(* The actual Roman numeral converter operating on Mathematica strings: *)
+
+romanNumerals = s \[Function] Fold[
+    (* conversion operating on pairs of subsequent values*)
+    Function[{a, ii}, If[GreaterEqual @@ ii, a + First[ii], a - First[ii]]],
+    0,
+    Partition[(* pairs of subsequent values*)
+     Append[ (* append zero so the last value still forms a pair *)
+      ReplaceAll[Characters[s], (* convert to list of decimal values *)
+       {"I" -> 1, "V" -> 5, "X" -> 10, "L" -> 50, "C" -> 100, "D" -> 500, "M" -> 1000}],
+      0],
+     2, 1]];
+
+(* The outer function provides the 'user interface': *)
+
+romanNumeralsMain = s \[Function]
+   Catch[
+    romanNumerals[
+     If[
+      StringQ[s] \[And] StringMatchQ[s, ("I" | "V" | "X" | "L" | "C" | "D" | "M") ...],
+      s,
+      Throw["Error: invalid string of roman numerals"]]]];
+
+
+(* Valid Tests *)
+
+Print /@ romanNumeralsMain /@ {
+    "", "I", "V", "X", "L", "C", "D", "M", "XXV", "XIV"
+    };
+
+
+(* Invalid Tests *)
+
+romanNumeralsMain["XT"]


### PR DESCRIPTION
## I Am Adding a New Code Snippet in an Existing Language

- [X] I fixed #2655 
- [X] I named the pull request using `Add {PROJECT} in {LANGUAGE}` format
  
  
## Other Notes

Please see my description in the Issue as to the structure of the code and why the tests can only be run manually; any such tests required by the project are included as part of the Pull Request and were verified by me (the author).

Note that this PR is a result of exporting the Mathematica Notebook as text, which drastically reduces its readability: within the Mathematica environment itself the Notebook looks much better, showing both input and output, elegantly formatted.  If you (the Web site maintainers) like, I can provide the Notebook contents as exported HTML (with or without MathML), and the original Notebooks themselves— just let me know.