### PR TITLE
Add ROT 13 in Mathematica

### DIFF
--- a/archive/m/mathematica/rot-13.nb
+++ b/archive/m/mathematica/rot-13.nb
@@ -1,0 +1,37 @@
+(* Code *)
+
+(* The actual rotation operating on Mathematica strings: *)
+
+rot13 = s \[Function] StringJoin @@ Function[{c},
+      FromCharacterCode @
+       Piecewise[(* operate piecewise on the domain of ASCII character codes *)
+        Append[{
+            Mod[c + 13, 26, First@ToCharacterCode[StringTake[#, 1]]],
+            Between[c, ToCharacterCode[#]]} & /@
+          {"az", "AZ"},(* specific character intervals to operate on *)
+         {c, True}] (* default does nothing *)
+        ]] /@ ToCharacterCode[s];
+
+(* The outer function provides the 'user interface': *)
+
+rot13Main = s \[Function]
+   Catch[
+    rot13[
+     If[
+      StringQ[s] \[And] \[Not] StringMatchQ[s, ""],
+      s,
+      Throw["Usage: please provide a string to encrypt"]]]];
+
+
+(* Valid Tests *)
+
+Print /@ rot13Main /@ {
+    "the quick brown fox jumped over the lazy dog",
+    "THE QUICK BROWN FOX JUMPED OVER THE LAZY DOG",
+    "The quick brown fox jumped. Was it over the lazy dog?"
+    };
+
+
+(* Invalid Tests *)
+
+rot13Main[""]


### PR DESCRIPTION
## I Am Adding a New Code Snippet in an Existing Language

- [X] I fixed #2656 
- [X] I named the pull request using `Add {PROJECT} in {LANGUAGE}` format
  
  
## Other Notes

Please see my description in the Issue as to the structure of the code and why the tests can only be run manually; any such tests required by the project are included as part of the Pull Request and were verified by me (the author).

Note that this PR is a result of exporting the Mathematica Notebook as text, which drastically reduces its readability: within the Mathematica environment itself the Notebook looks much better, showing both input and output, elegantly formatted.  If you (the Web site maintainers) like, I can provide the Notebook contents as exported HTML (with or without MathML), and the original Notebooks themselves— just let me know.