### PR TITLE
Test Suite Should Now Only Run If Changes Occur in Archive Directory

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -7,6 +7,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+    paths:
+      - 'archive/**'
 
 jobs:
   testing:


### PR DESCRIPTION
It's very annoying to wait for tests on code that isn't in the archive directory.