### PR TITLE
Indicate that python 3.8+ is needed for Contibuting Guide

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -287,7 +287,7 @@ To run the tests locally, **you will need the following dependencies**:
 - Docker
   - As there are so many languages in this project, we use docker to automatically generate
     consistent, stable build/test environments.
-- Python 3.7+
+- Python 3.8+
   - We use glotter as our testing library. Make sure you have python installed.
     Then use `pip install -r requirements.txt` (preferably in a virtual environment) to install glotter and its dependencies.
 


### PR DESCRIPTION
Since `glotter2` requires python 3.8+, the Contributing Guide need to be updated.

I fixed #2922 