### PR TITLE
Changed shell shebang from bash to sh in samplerunner.sh

### DIFF
--- a/samplerunner.sh
+++ b/samplerunner.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/bin/sh
 exec python runner.py "$@"


### PR DESCRIPTION
Adresses #2940 

Changes the shell used in samplerunner.sh to make the script work on OSs that do not have bash installed.

[renegade-coder]: https://therenegadecoder.com/
[contributing-plagiarism]: https://github.com/TheRenegadeCoder/sample-programs/blob/master/.github/CONTRIBUTING.md#plagiarism
[contributing-new-project]: https://github.com/TheRenegadeCoder/sample-programs/blob/master/.github/CONTRIBUTING.md#requirements-for-a-new-project
[contributing-readme]: https://github.com/TheRenegadeCoder/sample-programs/blob/master/.github/CONTRIBUTING.md#create-readmes
[contributing-tests-in-detail]: https://github.com/TheRenegadeCoder/sample-programs/blob/master/.github/CONTRIBUTING.md#tests-in-detail
[contributing]: ../CONTRIBUTING.md
[sample-programs-project-list]: https://sampleprograms.io/projects/
[contributing-modifications]: https://github.com/TheRenegadeCoder/sample-programs/blob/master/.github/CONTRIBUTING.md#modifying-existing-code-snippets
