### PR TITLE
Add Hello World in x86-64

### DIFF
--- a/archive/x/x86-64/hello-world.asm
+++ b/archive/x/x86-64/hello-world.asm
@@ -1,0 +1,18 @@
+section .rodata
+    message db 'Hello, World!', 0
+
+section .text
+    global _start
+
+_start:
+    ; write message to stdout
+    mov eax, 1 ; 1 is the system call number for write
+    mov edi, 1 ; 1 is the file descriptor for stdout
+    mov rsi, message ; address of the message to print
+    mov edx, 13 ; number of bytes to print
+    syscall ; invoke the system call
+
+    ; exit program with 0
+    mov eax, 60 ; 60 is the system call number for exit
+    xor edi, edi ; the exit status is stored in edi. Use xor to zero it out
+    syscall ; invoke the system call

--- a/archive/x/x86-64/hello-world.asm
+++ b/archive/x/x86-64/hello-world.asm
@@ -1,18 +1,19 @@
 section .rodata
-    message db 'Hello, World!', 0
+    message db 'Hello, World!'
+    message_len equ $-message
 
 section .text
     global _start
 
 _start:
     ; write message to stdout
-    mov eax, 1 ; 1 is the system call number for write
-    mov edi, 1 ; 1 is the file descriptor for stdout
+    mov rax, 1 ; 1 is the system call number for write
+    mov rdi, 1 ; 1 is the file descriptor for stdout
     mov rsi, message ; address of the message to print
-    mov edx, 13 ; number of bytes to print
+    mov rdx, message_len ; number of bytes to print
     syscall ; invoke the system call
 
     ; exit program with 0
-    mov eax, 60 ; 60 is the system call number for exit
-    xor edi, edi ; the exit status is stored in edi. Use xor to zero it out
+    mov rax, 60 ; 60 is the system call number for exit
+    xor rdi, rdi ; the exit status is stored in edi. Use xor to zero it out
     syscall ; invoke the system call

--- a/archive/x/x86-64/hello-world.asm
+++ b/archive/x/x86-64/hello-world.asm
@@ -15,5 +15,5 @@ _start:
 
     ; exit program with 0
     mov rax, 60 ; 60 is the system call number for exit
-    xor rdi, rdi ; the exit status is stored in edi. Use xor to zero it out
+    xor rdi, rdi ; the exit status is stored in rdi. Use xor to zero it out
     syscall ; invoke the system call

--- a/archive/x/x86-64/testinfo.yml
+++ b/archive/x/x86-64/testinfo.yml
@@ -1,0 +1,13 @@
+folder:
+  extension: ".asm"
+  naming: "hyphen"
+
+container:
+  image: "huntprod/asm"
+  tag: "latest"
+  # We need to both assemble and link the code.
+  # Using the sh command is necessary to run multiple commands,
+  # as Docker will not do any parsing and will pass the && as an actual argument
+  # if left to its own devices.
+  build: "sh -c 'nasm -f elf64 -g -o {{ source.name }}.o {{ source.name }}{{ source.extension }} && ld -g -o {{ source.name }} {{ source.name}}.o'"
+  cmd: "./{{ source.name }}"


### PR DESCRIPTION
## I Am Adding a New Code Snippet in a New Language

- [ x ] I fixed #3066 
- [ x ] I named the pull request using `Add {PROJECT} in {LANGUAGE}` format
- [ x ] I added a `testinfo.yml` files (see [contributing documentation][contributing-new-language])
- [ x ] I used an officially supported docker image or one that I personally trust


## Other Notes

The docker image isn't very official at all! I couldn't find anything great. Since there's no info on DockerHub, here's the GitHub info for it: [https://github.com/huntprod/docker-asm]( https://github.com/huntprod/docker-asm)

Not sure if there should be any attribution notes when leaning on an AI. I'm running a little experiment myself to see if I can learn x86-64 entirely from ChatGPT - I'm not allowed to Google anything or look at any tutorials. The code I'm submitting is not a direct copy-paste from ChatGPT; it's something I iterated on going between the chatbot, my own edits, and testing the code. As a result, I view this code as a collaboration between the chatbot and me. Should that be noted somewhere, or is in the near future something like this going to be as un-notable as saying "oh yeah I looked at StackOverflow as I was working on this?" Brave new world!