### PR TITLE
Update docker version

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -12,6 +12,8 @@ on:
       - 'test/**'
       - '.glotter.yml'
       - '.github/workflows/test-suite.yml'
+      - 'pyproject.toml'
+      - 'poetry.lock'
 
 jobs:
   testing:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: true
       matrix:
         python-version: ["3.11"]
-        poetry-version: ["1.4"]
+        poetry-version: ["1.4.2"]
         os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}

--- a/poetry.lock
+++ b/poetry.lock
@@ -241,19 +241,19 @@ gitdb = ">=4.0.1,<5"
 
 [[package]]
 name = "glotter2"
-version = "0.6.0"
+version = "0.6.1"
 description = "An execution library for scripts written in any language. This is a fork of https://github.com/auroq/glotter"
 category = "main"
 optional = false
 python-versions = ">=3.8,<4.0"
 files = [
-    {file = "glotter2-0.6.0-py3-none-any.whl", hash = "sha256:565b51d9bb637105d2bdbf91701898f00d6a121c82320527e6be241c5bada376"},
-    {file = "glotter2-0.6.0.tar.gz", hash = "sha256:6a266a0cf49e266fe727dcfc4fa8b7a509a2caa6410c8d7b5d2be161a0054134"},
+    {file = "glotter2-0.6.1-py3-none-any.whl", hash = "sha256:64b9fa3625e7277509fd417cab5d73d22fd53556f2476829afb15f4af83589af"},
+    {file = "glotter2-0.6.1.tar.gz", hash = "sha256:bede8b6f306014333aae1f190268fc26c21a7cb95c0f4f094de5d70bac6a6b59"},
 ]
 
 [package.dependencies]
 black = ">=23.1.0,<24.0.0"
-docker = ">=6.0.1,<7.0.0"
+docker = ">=6.1.0,<7.0.0"
 jinja2 = ">=3.1.2,<4.0.0"
 pydantic = ">=1.10.6,<2.0.0"
 pytest = ">=7.2.1,<8.0.0"
@@ -727,4 +727,4 @@ test = ["websockets"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "76679b445b688a3d78b489e1e4d94b6ce41faedc20d0c72a67067fa0a59ef5cc"
+content-hash = "635eba4fc8cff0ae589c759dc882973ce463dfbc42715b803507a5b8aa5bc29c"

--- a/poetry.lock
+++ b/poetry.lock
@@ -174,14 +174,14 @@ files = [
 
 [[package]]
 name = "docker"
-version = "6.0.1"
+version = "6.1.0"
 description = "A Python library for the Docker Engine API."
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "docker-6.0.1-py3-none-any.whl", hash = "sha256:dbcb3bd2fa80dca0788ed908218bf43972772009b881ed1e20dfc29a65e49782"},
-    {file = "docker-6.0.1.tar.gz", hash = "sha256:896c4282e5c7af5c45e8b683b0b0c33932974fe6e50fc6906a0a83616ab3da97"},
+    {file = "docker-6.1.0-py3-none-any.whl", hash = "sha256:b65c999f87cb5c31700b6944dc17a631071170d1aab3ad6e23506068579f885d"},
+    {file = "docker-6.1.0.tar.gz", hash = "sha256:cb697eccfeff55d232f7a7f4f88cd3770d27327c38d6c266b8f55c9f14a8491e"},
 ]
 
 [package.dependencies]
@@ -691,20 +691,21 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "1.26.15"
+version = "2.0.2"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+python-versions = ">=3.7"
 files = [
-    {file = "urllib3-1.26.15-py2.py3-none-any.whl", hash = "sha256:aa751d169e23c7479ce47a0cb0da579e3ede798f994f5816a74e4f4500dcea42"},
-    {file = "urllib3-1.26.15.tar.gz", hash = "sha256:8a388717b9476f934a21484e8c8e61875ab60644d29b9b39e11e4b9dc1c6b305"},
+    {file = "urllib3-2.0.2-py3-none-any.whl", hash = "sha256:d055c2f9d38dc53c808f6fdc8eab7360b6fdbbde02340ed25cfbcd817c62469e"},
+    {file = "urllib3-2.0.2.tar.gz", hash = "sha256:61717a1095d7e155cdb737ac7bb2f4324a858a1e2e6466f6d03ff630ca68d3cc"},
 ]
 
 [package.extras]
-brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
-secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
-socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
+secure = ["certifi", "cryptography (>=1.9)", "idna (>=2.0.0)", "pyopenssl (>=17.1.0)", "urllib3-secure-extra"]
+socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
+zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "websocket-client"
@@ -726,4 +727,4 @@ test = ["websockets"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "923a8811ceaac7ea87fae213d06777a891b3539b43238c7ddd2ef47e6e0515f4"
+content-hash = "76679b445b688a3d78b489e1e4d94b6ce41faedc20d0c72a67067fa0a59ef5cc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,7 @@ maintainers = [
 [tool.poetry.dependencies]
 python = "^3.11"
 ronbun = "^0.7"
-glotter2 = "^0.6"
-docker = "^6.1.0"
+glotter2 = "^0.6.1"
 
 [tool.pytest.ini_options]
 console_output_style = "count"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ maintainers = [
 python = "^3.11"
 ronbun = "^0.7"
 glotter2 = "^0.6"
-urllib3 = "<2"
+docker = "^6.1.0"
 
 [tool.pytest.ini_options]
 console_output_style = "count"


### PR DESCRIPTION
I fixed #3070 .

`glotter2` 0.6.1 updates the version of `docker` to 6.1.0, which is compatible with `urllib3` 2.x. I also changed the workflow so that changes to `pyproject.toml` and `poetry.lock` cause the Glotter action to run. I ran all the tests locally, and they all pass.