### PR TITLE
Try to eliminate 'latest' docker tag

### DIFF
--- a/archive/a/ada/testinfo.yml
+++ b/archive/a/ada/testinfo.yml
@@ -4,6 +4,6 @@ folder:
 
 container:
   image: "tomekw/ada-gnat"
-  tag: "latest" 
+  tag: "12.2.0" 
   build: "gnatmake {{ source.name }}{{ source.extension }}"
   cmd: "./{{ source.name }}"

--- a/archive/o/ocaml/testinfo.yml
+++ b/archive/o/ocaml/testinfo.yml
@@ -4,6 +4,6 @@ folder:
 
 container:
   image: "ocaml/ocaml"
-  tag: "latest"
+  tag: "centos-7"
   build: "ocamlc -o {{ source.name }} {{ source.name }}{{ source.extension }}"
   cmd: "./{{ source.name }}"

--- a/archive/r/r/testinfo.yml
+++ b/archive/r/r/testinfo.yml
@@ -4,5 +4,5 @@ folder:
 
 container:
   image: "r-base"
-  tag: "latest"
+  tag: "4.3.0"
   cmd: "Rscript {{ source.name }}{{ source.extension }}"


### PR DESCRIPTION
I fixed #3114 . Unfortunately, of the 14 images that used "latest", I could only find versioned docker images for Ada, OCAML, and R. For OCAML, I chose the smallest one, which is "centos-7". I couldn't get any of the "alpine" images to work.