### PR TITLE
Remove testinfo.yml for gerbil since it no longer works

### DIFF
--- a/archive/g/gerbil/testinfo.yml
+++ b/archive/g/gerbil/testinfo.yml
@@ -1,9 +1,0 @@
-folder:
-  extension: ".ss"
-  naming: "underscore"
-
-container:
-  image: "gerbil/ubuntu"
-  tag: "amd64"
-  build: "gxc -static -exe -o {{ source.name }} {{ source.name }}{{ source.extension }}"
-  cmd: "./{{ source.name }}"


### PR DESCRIPTION
The official docker image no longer works, and I can't get it to work.

fixes #3286 