### PR TITLE
Mark Mathematica as Untestable

### DIFF
--- a/archive/m/mathematica/untestable.yml
+++ b/archive/m/mathematica/untestable.yml
@@ -1,0 +1,1 @@
+- reason: "Mathematica requires a commercial license, so it cannot be tested"


### PR DESCRIPTION
I fixed #3641 . When this PR is merged, I'll do PRs for the following:

- [subete](https://github.com/TheRenegadeCoder/subete) - Add methods to indicate if untestable and to get the reason
- [sample-programs-readmes](https://github.com/TheRenegadeCoder/sample-programs-readmes) - Display untestable reason
- [sample-programs-website](https://github.com/TheRenegadeCoder/sample-programs-website) - Display number of untestable languages for a letter, and display "(untestable)" or something similar next to each untestable language on the [Lanugages page](https://sampleprograms.io/languages/)

I'll also need to do PRs to be able to use the newer versions of `subete` and `ronbun` once they release.