### PR TITLE
Run CodeQL for all samples in a language

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -120,10 +120,6 @@ jobs:
       if: ${{ matrix.language == 'c#' }}
       run: sudo apt-get update && sudo apt-get install -y mono-mcs
 
-    - name: Remove ignored paths
-      if: ${{ github.event_name == 'pull_request' }}
-      run: rm -f ${{ matrix.paths-ignore }}
-
     - name: Read repo config
       uses: pietrobolcato/action-read-yaml@1.1.0
       id: repo-config

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -116,9 +116,9 @@ jobs:
         distribution: 'oracle'
         java-version: '23'
 
-    - name: Install C# compiler
-      if: ${{ matrix.language == 'c#' }}
-      run: sudo apt-get update && sudo apt-get install -y mono-mcs
+    # - name: Install C# compiler
+    #  if: ${{ matrix.language == 'c#' }}
+    #  run: sudo apt-get update && sudo apt-get install -y mono-mcs
 
     - name: Read repo config
       uses: pietrobolcato/action-read-yaml@1.1.0

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -109,17 +109,6 @@ jobs:
       with:
         fetch-depth: 2
 
-    - name: Install Java 23
-      if: ${{ matrix.language == 'java' }}
-      uses: actions/setup-java@v4
-      with:
-        distribution: 'oracle'
-        java-version: '23'
-
-    # - name: Install C# compiler
-    #  if: ${{ matrix.language == 'c#' }}
-    #  run: sudo apt-get update && sudo apt-get install -y mono-mcs
-
     - name: Read repo config
       uses: pietrobolcato/action-read-yaml@1.1.0
       id: repo-config

--- a/scripts/build_codeql_language.py
+++ b/scripts/build_codeql_language.py
@@ -10,7 +10,6 @@ from glotter.source import Source
 TEST_INFO_DIR: Dict[str, str] = {
     "c": "c",
     "cpp": "c-plus-plus",
-    "c#": "c-sharp",
     "java": "java",
     "kotlin": "kotlin",
 }

--- a/scripts/get_codeql_languages.py
+++ b/scripts/get_codeql_languages.py
@@ -3,8 +3,7 @@ import json
 from collections import defaultdict
 from dataclasses import dataclass
 from fnmatch import fnmatch
-from pathlib import Path
-from typing import DefaultDict, Dict, List, Set
+from typing import DefaultDict, Dict, Set
 
 LINUX = "ubuntu-latest"
 MACOS = "macos-latest"
@@ -62,9 +61,6 @@ def main():
                 if fnmatch(changed_path, glob):
                     languages.add(language_info)
                     language_paths[language_info.language].add(glob)
-                    language_paths_ignore[language_info.language].update(
-                        str(path) for path in Path(".").glob(glob) if str(path) != changed_path
-                    )
                     break
 
     workflow_output = [
@@ -73,7 +69,6 @@ def main():
             "build-mode": language_info.build_mode,
             "os": language_info.os,
             "paths": " ".join(sorted(language_paths[language_info.language])),
-            "paths-ignore": " ".join(sorted(language_paths_ignore[language_info.language])),
         }
         for language_info in sorted(languages, key=lambda x: x.language)
     ]

--- a/scripts/get_codeql_languages.py
+++ b/scripts/get_codeql_languages.py
@@ -21,7 +21,7 @@ CODEQL_LANGUAGES: Dict[str, LanguageInfo] = {
     "scripts/*.py": LanguageInfo(language="python"),
     "archive/c/c/*.c": LanguageInfo(language="c", build_mode="manual"),
     "archive/c/c-plus-plus/*.cpp": LanguageInfo(language="cpp", build_mode="manual"),
-    "archive/c/c-sharp/*.cs": LanguageInfo(language="c#", build_mode="manual"),
+    "archive/c/c-sharp/*.cs": LanguageInfo(language="c#"),
     "archive/g/go/*.go": LanguageInfo(language="go", build_mode="autobuild"),
     "archive/j/java/*.java": LanguageInfo(language="java", build_mode="manual"),
     "archive/j/javascript/*.js": LanguageInfo(language="javascript"),


### PR DESCRIPTION
I fixed #4550 

Also in this PR:

- Changed `C#` to use a `build-mode` of `none` (see [this comment](https://github.com/github/codeql/issues/19033#issuecomment-2744087521))
- No longer necessary to install C# or Java in CodeQL workflow.