### PR TITLE
Add Swift to CodeQL again

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -306,7 +306,7 @@ To run the tests locally, **you will need the following dependencies**:
 - **Python 3.9+**: our build system is constructed with Python given that
   testing is built with glotter, a Python testing library that leverages docker. 
 - **Poetry**: our build system is managed and versioned using Poetry. Make sure
-  to use version **2.1.1** or later. If you are using an older version, please
+  to use version **2.1.3** or later. If you are using an older version, please
   update to the latest.
 
 With all three installed, the remaining dependencies can be installed using

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,10 +16,7 @@ on:
     branches: [ main ]
     paths:
       - '.github/workflows/codeql-analysis.yml'
-      - 'repo-config.yml'
       - 'scripts/*.py'
-      - 'pyproject.toml'
-      - 'poetry.lock'
       - 'archive/c/c/*.c'
       - 'archive/c/c/testinfo.yml'
       - 'archive/c/c-plus-plus/*.cpp'
@@ -45,10 +42,7 @@ on:
       - 'main'
     paths:
       - '.github/workflows/codeql-analysis.yml'
-      - 'repo-config.yml'
       - 'scripts/*.py'
-      - 'pyproject.toml'
-      - 'poetry.lock'
       - 'archive/c/c/*.c'
       - 'archive/c/c/testinfo.yml'
       - 'archive/c/c-plus-plus/*.cpp'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -129,17 +129,6 @@ jobs:
       with:
         fetch-depth: 2
 
-    - name: Read repo config
-      uses: pietrobolcato/action-read-yaml@1.1.0
-      id: repo-config
-      with:
-        config: repo-config.yml
-
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "${{ steps.repo-config.outputs['python-version'] }}"
-
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
@@ -162,7 +151,7 @@ jobs:
 
     - name: Manual build
       if: ${{ matrix.build-mode == 'manual' }}
-      run: poetry run python scripts/build_codeql_language.py ${{ matrix.language }} ${{ matrix.paths }}
+      run: python scripts/build_codeql_language.py ${{ matrix.language }} ${{ matrix.paths }}
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -140,14 +140,6 @@ jobs:
       with:
         python-version: "${{ steps.repo-config.outputs['python-version'] }}"
 
-    - name: Run Poetry Image
-      uses: abatilo/actions-poetry@v3
-      with:
-        poetry-version: "${{ steps.repo-config.outputs['poetry-version'] }}"
-        
-    - name: Install Dependencies
-      run: poetry install
-        
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3

--- a/scripts/build_codeql_language.py
+++ b/scripts/build_codeql_language.py
@@ -12,7 +12,7 @@ TEST_INFO_DIR: Dict[str, str] = {
     "cpp": "c-plus-plus",
     "java": "java",
     "kotlin": "kotlin",
-    "switft": "swift",
+    "swift": "swift",
 }
 
 

--- a/scripts/build_codeql_language.py
+++ b/scripts/build_codeql_language.py
@@ -14,8 +14,7 @@ TEST_INFO_DIR: Dict[str, str] = {
     "swift": "swift",
 }
 
-EXTENSION_PATTERN = re.compile(r"""^\s+extension:\s*['"](^'"]+)['"]""")
-BUILD_PATTERN = re.compile(r"""^\s+build:\s*['"]([^'"]+)['"]""")
+BUILD_PATTERN = re.compile(r"""^\s+build:\s*['"]([^'"]+)""", re.M)
 SOURCE_NAME_PATTERN = re.compile(r"\{\{\s*source\.name\s*\}\}")
 SOURCE_EXTENSION_PATTERN = re.compile(r"\{\{\s*source\.extension\s*\}\}")
 
@@ -47,12 +46,11 @@ def get_test_info_struct(language: str) -> TestInfoStruct:
 
 
 def get_build_command(testinfo_struct: TestInfoStruct, path: Path) -> List[str]:
-    test_info_str = testinfo_struct.test_info_str
-    extension = EXTENSION_PATTERN.sub(test_info_str, r"\g<1>")
-    source_name = path.name[: -len(extension)]
-    build = BUILD_PATTERN.sub(test_info_str, r"\g<1>")
-    build = SOURCE_NAME_PATTERN.sub(build, source_name)
-    build = SOURCE_EXTENSION_PATTERN.sub(build, extension)
+    match_str = BUILD_PATTERN.search(testinfo_struct.test_info_str)
+    assert match_str
+
+    build = SOURCE_NAME_PATTERN.sub(path.stem, match_str.group(1))
+    build = SOURCE_EXTENSION_PATTERN.sub(path.suffix, build)
     return shlex.split(build)
 
 

--- a/scripts/build_codeql_language.py
+++ b/scripts/build_codeql_language.py
@@ -12,6 +12,7 @@ TEST_INFO_DIR: Dict[str, str] = {
     "cpp": "c-plus-plus",
     "java": "java",
     "kotlin": "kotlin",
+    "switft": "swift",
 }
 
 

--- a/scripts/get_codeql_languages.py
+++ b/scripts/get_codeql_languages.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import DefaultDict, Dict, Set
 
 LINUX = "ubuntu-latest"
-MACOS = "macos-13"
+MACOS = "macos-latest"
 WINDOWS = "windows-latest"
 
 

--- a/scripts/get_codeql_languages.py
+++ b/scripts/get_codeql_languages.py
@@ -30,6 +30,7 @@ CODEQL_LANGUAGES: Dict[str, LanguageInfo] = {
     "archive/p/python/*.py": LanguageInfo(language="python"),
     "archive/r/ruby/*.rb": LanguageInfo(language="ruby"),
     "archive/t/typescript/*.ts": LanguageInfo(language="typescript"),
+    "archive/s/swift/*.swift": LanguageInfo(language="swift", build_mode="manual", os=MACOS),
 }
 ALL_CODEQL_LANGUAGES_FILES = {
     ".github/workflows/codeql-analysis.yml",

--- a/scripts/get_codeql_languages.py
+++ b/scripts/get_codeql_languages.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import DefaultDict, Dict, Set
 
 LINUX = "ubuntu-latest"
-MACOS = "macos-latest"
+MACOS = "macos-14"
 WINDOWS = "windows-latest"
 
 

--- a/scripts/get_codeql_languages.py
+++ b/scripts/get_codeql_languages.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import DefaultDict, Dict, Set
 
 LINUX = "ubuntu-latest"
-MACOS = "macos-14"
+MACOS = "macos-13"
 WINDOWS = "windows-latest"
 
 


### PR DESCRIPTION
I fixed #4721 . For some reason `poetry` is not installing the correct wheel for `pydantic` in MacOS. Therefore, I used regexes instead of `glotter`. Not a great solution, but it seems to work, and it simplifies the workflow quite a bit.