### PR TITLE
Add Capitalize in OCaml

### DIFF
--- a/archive/o/ocaml/capitalize.ml
+++ b/archive/o/ocaml/capitalize.ml
@@ -1,0 +1,4 @@
+let () = print_endline (
+  match Array.to_list Sys.argv with
+  | [] | [_] | [_; ""] -> "Usage: please provide a string"
+  | _::args -> args |> String.concat " " |> String.capitalize_ascii)

--- a/archive/o/ocaml/testinfo.yml
+++ b/archive/o/ocaml/testinfo.yml
@@ -5,7 +5,6 @@ folder:
   naming: "hyphen"
 
 container:
-  image: "ocaml/ocaml"
-  tag: "centos-7"
-  build: "ocamlc -o {{ source.name }} {{ source.name }}{{ source.extension }}"
-  cmd: "./{{ source.name }}"
+  image: "ocaml/opam"
+  tag: "ubuntu-lts-ocaml-5.6"
+  cmd: "/home/opam/.opam/5.6/bin/ocaml {{ source.name }}{{ source.extension }}"


### PR DESCRIPTION
## I Am Adding a New Code Snippet in an Existing Language

- [x] I fixed #5955
- [x] I did not include any extra folders/libraries
- [x] I named the pull request using `Add Capitalize in OCaml` format
 
## Other Notes

This builds on (#5957) because it needs `String.capitalize_ascii` which is the idiomatic way to achieve this task in modern OCaml but is not present in old version of OCaml from the old image. 
