### PR TITLE
Cleanup GitHub workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -95,7 +95,7 @@ jobs:
 
     - name: Get changed code files
       id: changed-files
-      uses: tj-actions/changed-files@934b2d2c7e653bb8c968afed5a0428617f09aa24
+      uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
 
     - name: List all relevant changed files
       if: steps.changed-files.outputs.any_changed == 'true'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -136,7 +136,7 @@ jobs:
         fetch-depth: 2
 
     - name: Read repo config
-      uses: pietrobolcato/action-read-yaml@1.1.0
+      uses: rzuckerm/action-simple-yaml-reader@main
       id: repo-config
       with:
         config: repo-config.yml
@@ -144,12 +144,12 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: "${{ steps.repo-config.outputs['python-version'] }}"
+        python-version: "${{ steps.repo-config.outputs.python-version }}"
 
     - name: Run Poetry Image
       uses: abatilo/actions-poetry@v4
       with:
-        poetry-version: "${{ steps.repo-config.outputs['poetry-version'] }}"
+        poetry-version: "${{ steps.repo-config.outputs.poetry-version }}"
 
     - name: Install Dependencies
       run: poetry install

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -136,7 +136,7 @@ jobs:
         fetch-depth: 2
 
     - name: Read repo config
-      uses: rzuckerm/action-simple-yaml-reader@main
+      uses: Elisity/action-read-yaml@v0.2
       id: repo-config
       with:
         config: repo-config.yml
@@ -144,12 +144,12 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python_version: "${{ steps.repo-config.outputs.python_version }}"
+        python-version: "${{ steps.repo-config.outputs['python-version'] }}"
 
     - name: Run Poetry Image
       uses: abatilo/actions-poetry@v4
       with:
-        poetry_version: "${{ steps.repo-config.outputs.poetry_version }}"
+        poetry-version: "${{ steps.repo-config.outputs['poetry-version'] }}"
 
     - name: Install Dependencies
       run: poetry install

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -144,12 +144,12 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: "${{ steps.repo-config.outputs.python-version }}"
+        python_version: "${{ steps.repo-config.outputs.python_version }}"
 
     - name: Run Poetry Image
       uses: abatilo/actions-poetry@v4
       with:
-        poetry-version: "${{ steps.repo-config.outputs.poetry-version }}"
+        poetry_version: "${{ steps.repo-config.outputs.poetry_version }}"
 
     - name: Install Dependencies
       run: poetry install

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -154,6 +154,11 @@ jobs:
     - name: Install Dependencies
       run: poetry install
 
+    # Set up C# for scanning.
+    - name: Set up C#
+      if: ${{ matrix.language == 'c#' }}
+      run: python scripts/generate_c_sharp_project_file.py
+
     # Workaround for Kotlin scanning.
     - name: Set up Kotlin
       if: ${{ matrix.language == 'kotlin' }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -157,7 +157,7 @@ jobs:
     # Set up C# for scanning.
     - name: Set up C#
       if: ${{ matrix.language == 'c#' }}
-      run: python scripts/generate_c_sharp_project_file.py
+      run: poetry run python scripts/generate_c_sharp_project_file.py
 
     # Workaround for Kotlin scanning.
     - name: Set up Kotlin

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -87,7 +87,7 @@ jobs:
 
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
-      changed-files: ${{ steps.changed-files.outputs.files }}
+      changed-files: ${{ steps.changed-files.outputs.all_changed_files }}
     steps:
     - uses: actions/checkout@v6
       with:
@@ -95,12 +95,12 @@ jobs:
 
     - name: Get changed code files
       id: changed-files
-      uses: yumemi-inc/changed-files@v3
+      uses: tj-actions/changed-files@934b2d2c7e653bb8c968afed5a0428617f09aa24
 
     - name: List all relevant changed files
-      if: steps.changed-files.outputs.exists == 'true'
+      if: steps.changed-files.outputs.any_changed == 'true'
       env:
-        ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.files }}
+        ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
       run: |
         for file in ${ALL_CHANGED_FILES}; do
           echo "$file was changed"
@@ -110,7 +110,7 @@ jobs:
     - name: Get CodeQL Languages
       id: set-matrix
       run: |
-        matrix=$(python scripts/get_codeql_languages.py --event ${{ github.event_name}} ${{ steps.changed-files.outputs.files }})
+        matrix=$(python scripts/get_codeql_languages.py --event ${{ github.event_name}} ${{ steps.changed-files.outputs.all_changed_files }})
         echo "${matrix}"
         echo "matrix={\"include\": ${matrix}}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -27,12 +27,12 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: "${{ steps.repo-config.outputs.python-version }}"
+        python_version: "${{ steps.repo-config.outputs.python_version }}"
 
     - name: Run Poetry Image
       uses: abatilo/actions-poetry@v4
       with:
-        poetry-version: "${{ steps.repo-config.outputs.poetry-version }}"
+        poetry_version: "${{ steps.repo-config.outputs.poetry_version }}"
 
     - name: Install Dependencies
       run: poetry install

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -19,7 +19,7 @@ jobs:
         fetch-depth: 2
 
     - name: Read repo config
-      uses: rzuckerm/action-simple-yaml-reader@main
+      uses: Elisity/action-read-yaml@v0.2
       id: repo-config
       with:
         config: repo-config.yml
@@ -27,12 +27,12 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python_version: "${{ steps.repo-config.outputs.python_version }}"
+        python-version: "${{ steps.repo-config.outputs['python-version'] }}"
 
     - name: Run Poetry Image
       uses: abatilo/actions-poetry@v4
       with:
-        poetry_version: "${{ steps.repo-config.outputs.poetry_version }}"
+        poetry-version: "${{ steps.repo-config.outputs['poetry-version'] }}"
 
     - name: Install Dependencies
       run: poetry install

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -19,7 +19,7 @@ jobs:
         fetch-depth: 2
 
     - name: Read repo config
-      uses: pietrobolcato/action-read-yaml@1.1.0
+      uses: rzuckerm/action-simple-yaml-reader@main
       id: repo-config
       with:
         config: repo-config.yml
@@ -27,12 +27,12 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: "${{ steps.repo-config.outputs['python-version'] }}"
+        python-version: "${{ steps.repo-config.outputs.python-version }}"
 
     - name: Run Poetry Image
       uses: abatilo/actions-poetry@v4
       with:
-        poetry-version: "${{ steps.repo-config.outputs['poetry-version'] }}"
+        poetry-version: "${{ steps.repo-config.outputs.poetry-version }}"
 
     - name: Install Dependencies
       run: poetry install

--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -33,7 +33,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Read repo config
-      uses: pietrobolcato/action-read-yaml@1.1.0
+      uses: rzuckerm/action-simple-yaml-reader@main
       id: repo-config
       with:
         config: repo-config.yml
@@ -41,12 +41,12 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: "${{ steps.repo-config.outputs['python-version'] }}"
+        python-version: "${{ steps.repo-config.outputs.python-version }}"
 
     - name: Run Poetry Image
       uses: abatilo/actions-poetry@v4
       with:
-        poetry-version: "${{ steps.repo-config.outputs['poetry-version'] }}"
+        poetry-version: "${{ steps.repo-config.outputs.poetry-version }}"
         
     - name: Install Dependencies
       run: poetry install

--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -41,12 +41,12 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: "${{ steps.repo-config.outputs.python-version }}"
+        python_version: "${{ steps.repo-config.outputs.python_version }}"
 
     - name: Run Poetry Image
       uses: abatilo/actions-poetry@v4
       with:
-        poetry-version: "${{ steps.repo-config.outputs.poetry-version }}"
+        poetry_version: "${{ steps.repo-config.outputs.poetry_version }}"
         
     - name: Install Dependencies
       run: poetry install

--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -33,7 +33,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Read repo config
-      uses: rzuckerm/action-simple-yaml-reader@main
+      uses: Elisity/action-read-yaml@v0.2
       id: repo-config
       with:
         config: repo-config.yml
@@ -41,12 +41,12 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python_version: "${{ steps.repo-config.outputs.python_version }}"
+        python-version: "${{ steps.repo-config.outputs['python-version'] }}"
 
     - name: Run Poetry Image
       uses: abatilo/actions-poetry@v4
       with:
-        poetry_version: "${{ steps.repo-config.outputs.poetry_version }}"
+        poetry-version: "${{ steps.repo-config.outputs['poetry-version'] }}"
         
     - name: Install Dependencies
       run: poetry install

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -92,12 +92,12 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: "${{ steps.repo-config.outputs.python-version }}"
+        python_version: "${{ steps.repo-config.outputs.python_version }}"
 
     - name: Run Poetry Image
       uses: abatilo/actions-poetry@v4
       with:
-        poetry-version: "${{ steps.repo-config.outputs.poetry-version }}"
+        poetry_version: "${{ steps.repo-config.outputs.poetry_version }}"
 
     - name: Install Dependencies
       run: poetry install
@@ -108,7 +108,7 @@ jobs:
     - name: Download Docker images, Test Appropriate Sample Programs, Remove Docker Images
       run: poetry run python scripts/run_tests.py
         --event ${{ github.event_name }}
-        --num-batches ${{ steps.repo-config.outputs.num-batches }}
+        --num_batches ${{ steps.repo-config.outputs.num_batches }}
         --parallel
         --remove
         ${{ needs.changed-files.outputs.changed_files }}

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      status: ${{ steps.changed-files.outputs.exists }}
+      status: ${{ steps.changed-files.outputs.any_changed }}
       changed_files: ${{ steps.changed-files.outputs.all_changed_files }}
     steps:
     - uses: actions/checkout@v6
@@ -111,7 +111,7 @@ jobs:
         --num-batches ${{ steps.repo-config.outputs['num-batches'] }}
         --parallel
         --remove
-        ${{ needs.changed-files.outputs.all_changed_files }}
+        ${{ needs.changed-files.outputs.changed_files }}
 
   # Because testing uses a matrix, we need this job for branch protections
   test-results:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -33,7 +33,7 @@ jobs:
 
     outputs:
       status: ${{ steps.changed-files.outputs.exists }}
-      changed_files: ${{ steps.changed-files.outputs.files }}
+      changed_files: ${{ steps.changed-files.outputs.all_changed_files }}
     steps:
     - uses: actions/checkout@v6
       with:
@@ -111,7 +111,7 @@ jobs:
         --num-batches ${{ steps.repo-config.outputs['num-batches'] }}
         --parallel
         --remove
-        ${{ needs.changed-files.outputs.changed_files }}
+        ${{ needs.changed-files.outputs.all_changed_files }}
 
   # Because testing uses a matrix, we need this job for branch protections
   test-results:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -41,9 +41,9 @@ jobs:
 
     - name: Get changed code files
       id: changed-files
-      uses: yumemi-inc/changed-files@v3
+      uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
       with:
-        patterns: |
+        files: |
           archive/**
           .glotter.yml
           repo-config.yml
@@ -54,9 +54,9 @@ jobs:
           !**/*.md
 
     - name: List all relevant changed files
-      if: steps.changed-files.outputs.exists == 'true'
+      if: steps.changed-files.outputs.any_changed == 'true'
       env:
-        ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.files }}
+        ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
       run: |
         for file in ${ALL_CHANGED_FILES}; do
           echo "$file was changed"

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -43,7 +43,7 @@ jobs:
       id: changed-files
       uses: tj-actions/changed-files@934b2d2c7e653bb8c968afed5a0428617f09aa24
       with:
-        patterns: |
+        files: |
           archive/**
           .glotter.yml
           repo-config.yml

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -32,8 +32,8 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      status: ${{ steps.changed-files.outputs.exists }}
-      changed_files: ${{ steps.changed-files.outputs.files }}
+      status: ${{ steps.changed-files.outputs.any_changed }}
+      changed_files: ${{ steps.changed-files.outputs.all_changed_files }}
     steps:
     - uses: actions/checkout@v6
       with:
@@ -41,7 +41,7 @@ jobs:
 
     - name: Get changed code files
       id: changed-files
-      uses: yumemi-inc/changed-files@v3
+      uses: tj-actions/changed-files@934b2d2c7e653bb8c968afed5a0428617f09aa24
       with:
         patterns: |
           archive/**
@@ -54,9 +54,9 @@ jobs:
           !**/*.md
 
     - name: List all relevant changed files
-      if: steps.changed-files.outputs.exists == 'true'
+      if: steps.changed-files.outputs.any_changed == 'true'
       env:
-        ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.files }}
+        ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
       run: |
         for file in ${ALL_CHANGED_FILES}; do
           echo "$file was changed"

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -84,7 +84,7 @@ jobs:
         fetch-depth: 2
 
     - name: Read repo config
-      uses: pietrobolcato/action-read-yaml@1.1.0
+      uses: rzuckerm/action-simple-yaml-reader@main
       id: repo-config
       with:
         config: repo-config.yml
@@ -92,12 +92,12 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: "${{ steps.repo-config.outputs['python-version'] }}"
+        python-version: "${{ steps.repo-config.outputs.python-version }}"
 
     - name: Run Poetry Image
       uses: abatilo/actions-poetry@v4
       with:
-        poetry-version: "${{ steps.repo-config.outputs['poetry-version'] }}"
+        poetry-version: "${{ steps.repo-config.outputs.poetry-version }}"
 
     - name: Install Dependencies
       run: poetry install
@@ -108,7 +108,7 @@ jobs:
     - name: Download Docker images, Test Appropriate Sample Programs, Remove Docker Images
       run: poetry run python scripts/run_tests.py
         --event ${{ github.event_name }}
-        --num-batches ${{ steps.repo-config.outputs['num-batches'] }}
+        --num-batches ${{ steps.repo-config.outputs.num-batches }}
         --parallel
         --remove
         ${{ needs.changed-files.outputs.changed_files }}

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -32,8 +32,8 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      status: ${{ steps.changed-files.outputs.any_changed }}
-      changed_files: ${{ steps.changed-files.outputs.all_changed_files }}
+      status: ${{ steps.changed-files.outputs.exists }}
+      changed_files: ${{ steps.changed-files.outputs.files }}
     steps:
     - uses: actions/checkout@v6
       with:
@@ -41,9 +41,9 @@ jobs:
 
     - name: Get changed code files
       id: changed-files
-      uses: tj-actions/changed-files@934b2d2c7e653bb8c968afed5a0428617f09aa24
+      uses: yumemi-inc/changed-files@v3
       with:
-        files: |
+        patterns: |
           archive/**
           .glotter.yml
           repo-config.yml
@@ -54,9 +54,9 @@ jobs:
           !**/*.md
 
     - name: List all relevant changed files
-      if: steps.changed-files.outputs.any_changed == 'true'
+      if: steps.changed-files.outputs.exists == 'true'
       env:
-        ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+        ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.files }}
       run: |
         for file in ${ALL_CHANGED_FILES}; do
           echo "$file was changed"
@@ -84,7 +84,7 @@ jobs:
         fetch-depth: 2
 
     - name: Read repo config
-      uses: rzuckerm/action-simple-yaml-reader@main
+      uses: Elisity/action-read-yaml@v0.2
       id: repo-config
       with:
         config: repo-config.yml
@@ -92,12 +92,12 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python_version: "${{ steps.repo-config.outputs.python_version }}"
+        python-version: "${{ steps.repo-config.outputs['python-version'] }}"
 
     - name: Run Poetry Image
       uses: abatilo/actions-poetry@v4
       with:
-        poetry_version: "${{ steps.repo-config.outputs.poetry_version }}"
+        poetry-version: "${{ steps.repo-config.outputs['poetry-version'] }}"
 
     - name: Install Dependencies
       run: poetry install
@@ -108,7 +108,7 @@ jobs:
     - name: Download Docker images, Test Appropriate Sample Programs, Remove Docker Images
       run: poetry run python scripts/run_tests.py
         --event ${{ github.event_name }}
-        --num_batches ${{ steps.repo-config.outputs.num_batches }}
+        --num-batches ${{ steps.repo-config.outputs['num-batches'] }}
         --parallel
         --remove
         ${{ needs.changed-files.outputs.changed_files }}

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ Program.fs
 # Rust
 Cargo.toml
 Cargo.lock
+
+# C#
+*.csproj

--- a/scripts/generate_c_sharp_project_file.py
+++ b/scripts/generate_c_sharp_project_file.py
@@ -12,6 +12,11 @@ C_SHARP_PROJECT_CONTENTS = """\
       <Nullable>enable</Nullable>
       <Deterministic>true</Deterministic>
   </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Exclude all .cs files; the build process handles compilation individually -->
+    <Compile Remove="**/*.cs" />
+  </ItemGroup>
 </Project>
 """
 

--- a/scripts/generate_c_sharp_project_file.py
+++ b/scripts/generate_c_sharp_project_file.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+import yaml
+
+C_SHARP_ARCHIVE_DIR = Path("archive/c/c-sharp")
+C_SHARP_PROJECT_CONTENTS = """\
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+      <TargetFramework>net{version}</TargetFramework>
+      <ImplicitUsings>enable</ImplicitUsings>
+      <Nullable>enable</Nullable>
+      <Deterministic>true</Deterministic>
+  </PropertyGroup>
+</Project>
+"""
+
+
+
+def main():
+    testinfo = yaml.safe_load((C_SHARP_ARCHIVE_DIR / "testinfo.yml").read_text(encoding="utf-8"))
+    tag = testinfo["container"]["tag"]
+    project_contents = C_SHARP_PROJECT_CONTENTS.format(version=tag)
+    (C_SHARP_ARCHIVE_DIR / "MyProj.csproj").write_text(project_contents, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/get_codeql_languages.py
+++ b/scripts/get_codeql_languages.py
@@ -22,7 +22,7 @@ CODEQL_LANGUAGES: Dict[str, LanguageInfo] = {
     "scripts/*.py": LanguageInfo(language="python"),
     "archive/c/c/*.c": LanguageInfo(language="c", build_mode="manual"),
     "archive/c/c-plus-plus/*.cpp": LanguageInfo(language="cpp", build_mode="manual"),
-    "archive/c/c-sharp/*.cs": LanguageInfo(language="c#"),
+    "archive/c/c-sharp/*.cs": LanguageInfo(language="c#", build_mode="autobuild"),
     "archive/g/go/*.go": LanguageInfo(language="go", build_mode="autobuild"),
     "archive/j/java/*.java": LanguageInfo(language="java", build_mode="manual"),
     "archive/j/javascript/*.js": LanguageInfo(language="javascript"),


### PR DESCRIPTION
This PR addresses the following:

- I fixed #6009 
- I fixed #6011 
- I fixed #5354 

Notes:

- It was recommended that a specific hash be used for [tj-actions/changed-files](https://github.com/tj-actions/changed-files) to guard against supply-chain attacks. In general, I'm wondering if we should do this for all of our actions
- It was recommended that a project file be added for C# and to change the build mode to `autobuild` to fix the CodeQL low quality scan issue
- I found [Elisity/action-read-yaml](https://github.com/Elisity/action-read-yaml) as a replacement for `pietrobolcato/action-read-yaml`. It is identical except it is using Node 24 instead of Node 20